### PR TITLE
De-GitHub

### DIFF
--- a/lib/github/html/plain_text_input_filter.rb
+++ b/lib/github/html/plain_text_input_filter.rb
@@ -1,9 +1,11 @@
+require 'escape_utils'
+
 module GitHub::HTML
   # Simple filter for plain text input. HTML escapes the text input and wraps it
   # in a div.
   class PlainTextInputFilter < TextFilter
     def call
-      "<div>#{EscapeUtils.escape_html(@text)}</div>"
+      "<div>#{EscapeUtils.escape_html(@text, false)}</div>"
     end
   end
 end


### PR DESCRIPTION
This should really just be a general purpose library I think. We should move everything out from `GitHub::*` and just grab a root namespace like `HTMLPipeline` or something.
