### PR TITLE
Loosen Gemoji restriction

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^test})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'gemoji',          '~> 1.1.1'
+  gem.add_dependency 'gemoji',          '~> 1.0'
   gem.add_dependency 'nokogiri',        '~> 1.4'
   gem.add_dependency 'github-markdown', '~> 0.5'
   gem.add_dependency 'sanitize',        '~> 2.0'


### PR DESCRIPTION
Trying to ship an emoji update.

```
Bundler could not find compatible versions for gem "gemoji":
  In Gemfile:
    html-pipeline (>= 0) ruby depends on
      gemoji (~> 1.1.1) ruby

    gemoji (1.2.0)
```

No need to be this uptight.

The api html-pipeline needs works on 1.0. Just let anything 1.x work.
