### PR TITLE
Add MIT license indicator to the gemspec.

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/html/pipeline/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.name          = "html-pipeline"
   gem.version       = HTML::Pipeline::VERSION
-  gem.license       = 'MIT'
+  gem.license       = "MIT"
   gem.authors       = ["Ryan Tomayko", "Jerry Cheung"]
   gem.email         = ["ryan@github.com", "jerry@github.com"]
   gem.description   = %q{GitHub HTML processing filters and utilities}


### PR DESCRIPTION
This pull simply adds the MIT license indicator to the gemspec.  This benefits developers by allowing Rubygems.org to display the proper license on the gem page and gives automated license checkers the ability to determine the intended license without looking into the repository.
