### PR TITLE
remove github-linguist dependency

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "nokogiri",        "~> 1.4"
   gem.add_dependency "github-markdown", "~> 0.5"
   gem.add_dependency "sanitize",        "~> 2.0"
-  gem.add_dependency "github-linguist", "~> 2.1"
+  gem.add_dependency "pygments.rb",     ">= 0.2.13"
   gem.add_dependency "rinku",           "~> 1.7"
   gem.add_dependency "escape_utils",    "~> 0.2"
   gem.add_dependency "activesupport",   ">= 2"

--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -1,4 +1,4 @@
-require 'linguist'
+require 'pygments'
 
 module HTML
   class Pipeline

--- a/test/html/pipeline/syntax_highlight_filter_test.rb
+++ b/test/html/pipeline/syntax_highlight_filter_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class HTML::Pipeline::SyntaxHighlightFilterTest < Test::Unit::TestCase
+  HighlightFilter = HTML::Pipeline::SyntaxHighlightFilter
+
+  def filter(*args)
+    HighlightFilter.call(*args)
+  end
+
+  def test_unchanged
+    html = "<pre>plain</pre>"
+    assert_equal html, filter(html).to_s
+  end
+
+  def test_syntax_highlighting
+    html = "<pre lang=rb>a = 1</pre>"
+    assert_equal_html <<-RESULT, filter(html).to_s
+      <div class="highlight">
+        <pre>
+        <span class="n">a</span> <span class="o">=</span> <span class="mi">1</span>
+        </pre>
+      </div>
+    RESULT
+  end
+end


### PR DESCRIPTION
It seems to be unnecessary since syntax highlighting filter only depends
on Pygments directly.
