### PR TITLE
fix syntax highlighting example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ pipeline = HTML::Pipeline.new [
 result = pipeline.call <<CODE
 This is *great*:
 
-    some_code(:first)
+``` ruby
+some_code(:first)
+```
 
 CODE
 result[:output].to_s


### PR DESCRIPTION
Markdown has to first output a <pre> with a "lang" attribute for syntax 
highlighting filter to be able to pick it up.
