### PR TITLE
Fix typo on readme in "AutolinkFilter" doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ filter.call
 ## Filters
 
 * `MentionFilter` - replace `@user` mentions with links
-* `AutoLinkFilter` - auto_linking urls in HTML
+* `AutolinkFilter` - auto_linking urls in HTML
 * `CamoFilter` - replace http image urls with [camo-fied](https://github.com/atmos/camo) https versions
 * `EmailReplyFilter` - util filter for working with emails
 * `EmojiFilter` - everyone loves [emoji](http://www.emoji-cheat-sheet.com/)!


### PR DESCRIPTION
Caps error in the doc for AutolinkFilter caused me some confusion when cutting and pasting the filter name into my code.  This pull should save others from the same fate.

(ps. thanks for this project.  Very cool and very useful.)
