### PR TITLE
use #gsub instead of #gsub! in MarkdownFilter#initialize

### DIFF
--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -13,7 +13,7 @@ module HTML
     class MarkdownFilter < TextFilter
       def initialize(text, context = nil, result = nil)
         super text, context, result
-        @text.gsub! "\r", ''
+        @text = @text.gsub "\r", ''
       end
 
       # Convert Markdown to HTML using the best available implementation


### PR DESCRIPTION
This caused me a weird bug that took a long time to track down because it mutated the String which came from far outside of the library. Using `#gsub` instead will leave the original String as it was.
