### PR TITLE
Add IRC URLs to URL scheme filter

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -58,7 +58,7 @@ module HTML
                     'vspace', 'width', 'itemprop']
         },
         :protocols => {
-          'a'   => {'href' => ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']},
+          'a'   => {'href' => ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'irc']},
           'img' => {'src'  => ['http', 'https', :relative]}
         },
         :transformers => [


### PR DESCRIPTION
[IRC](https://tools.ietf.org/html/rfc1459.html) is a protocol popular among open source software developers for instant chat. There is a [standard](http://www.w3.org/Addressing/draft-mirashi-url-irc-01.txt) URL scheme for IRC that allows users to join channels and chat to the relevant people quickly. This pull request adds these URLs to the URL scheme filter.

Not included in this pull request is support for magnet links. I would appreciate it if you'd consider adding these as well, for the sake of distributing my [bittorrent client](https://github.com/SirCmpwn/Patchy).
