### PR TITLE
add result[:mentioned_usernames] for MentionFilter

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -60,6 +60,8 @@ module HTML
       IGNORE_PARENTS = %w(pre code a).to_set
 
       def call
+        result[:mentioned_usernames] ||= []
+
         doc.search('text()').each do |node|
           content = node.to_html
           next if !content.include?('@')
@@ -108,6 +110,7 @@ module HTML
       end
 
       def link_to_mentioned_user(login)
+        result[:mentioned_usernames] |= [login]
         url = File.join(base_url, login)
         "<a href='#{url}' class='user-mention'>" +
         "@#{login}" +

--- a/test/html/pipeline/mention_filter_test.rb
+++ b/test/html/pipeline/mention_filter_test.rb
@@ -76,9 +76,7 @@ class HTML::Pipeline::MentionFilterTest < Test::Unit::TestCase
   def mentioned_usernames
     result = {}
     MarkdownPipeline.call(@body, {}, result)
-    html = result[:output].to_html
-    users = html.scan(/user-mention">@(.+?)</)
-    users ? users.flatten.uniq : []
+    result[:mentioned_usernames]
   end
 
   def test_matches_usernames_in_body


### PR DESCRIPTION
``` ruby
MarkdownPipeline = HTML::Pipeline.new [
  HTML::Pipeline::MarkdownFilter,
  HTML::Pipeline::MentionFilter
]

body = '@fahchen @test'
result = MarkdownPipeline.call(body)
result[:mentioned_usernames] # => ['fahchen', 'test']

no_result_body = 'hello world'
no_result = MarkdownPipeline.call(no_result_body)
no_result[:mentioned_usernames] # => []
```

useful to send notification to mentioned_usernames
