### PR TITLE
Add an html-pipeline executable to the gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-bin/*
+exec/*
 vendor/gems

--- a/bin/html-pipeline
+++ b/bin/html-pipeline
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+require 'html/pipeline'
+
+require 'optparse'
+
+# Accept "help", too
+ARGV.map!{|a| a == "help" ? "--help" : a }
+
+OptionParser.new do |opts|
+  opts.banner = <<-HELP.gsub(/^    /, '')
+    Usage: html-pipeline [-h] [-f]
+           html-pipeline [FILTER [FILTER [...]]] < file.md
+           cat file.md | html-pipeline [FILTER [FILTER [...]]]
+  HELP
+
+  opts.separator "Options:"
+
+  opts.on("-f", "--filters", "List the available filters") do
+    filters = HTML::Pipeline.constants.grep(/\w+Filter$/).
+      map{|f| f.to_s.gsub(/Filter$/,'') }
+
+    # Text filter doesn't work, no call method
+    filters -= ["Text"]
+
+    abort <<-HELP.gsub(/^      /, '')
+      Available filters:
+        #{filters.join("\n        ")}
+    HELP
+  end
+end.parse!
+
+# Default to a GitHub-ish pipeline
+if ARGV.empty?
+
+  filters = [
+    HTML::Pipeline::MarkdownFilter,
+    HTML::Pipeline::SanitizationFilter,
+    HTML::Pipeline::ImageMaxWidthFilter,
+    HTML::Pipeline::EmojiFilter,
+    HTML::Pipeline::AutolinkFilter,
+    HTML::Pipeline::TableOfContentsFilter,
+  ]
+
+  # Add syntax highlighting if linguist is present
+  begin
+    require 'linguist'
+    filters << HTML::Pipeline::SyntaxHighlightFilter
+  rescue LoadError
+  end
+
+else
+
+  def filter_named(name)
+    case name
+    when "Text"
+      raise NameError # Text filter doesn't work, no call method
+    when "Textile"
+      require "RedCloth" # Textile filter doesn't require RedCloth
+    end
+
+    HTML::Pipeline.const_get("#{name}Filter")
+  rescue NameError => e
+    abort "Unknown filter '#{name}'. List filters with the -f option."
+  end
+
+  filters = []
+  until ARGV.empty?
+    name = ARGV.shift
+    filters << filter_named(name)
+  end
+
+end
+
+context = {
+  :asset_root => "/assets",
+  :base_url   => "/",
+  :gfm        => true
+}
+
+puts HTML::Pipeline.new(filters, context).call(ARGF.read)[:output]


### PR DESCRIPTION
Usage: html-pipeline [-h|--help|help] [-f|--filters]
      html-pipeline [FILTER [FILTER [...]]] < file.md
      cat file.md | html-pipeline [FILTER [FILTER [...]]]

Also stop gitignoring bin/, but ignore exec/ instead for binstubs.
