### PR TITLE
Instrument filters in the pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ Pipeline.new [ RootRelativeFilter ], { :base_url => 'http://somehost.com' }
 
 ## Instrumenting
 
-To instrument each filter, set an [ActiveSupport::Notifications]
-(http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) service
-object on a pipeline object. New pipeline objects will default to the
+To instrument each filter and a full pipeline call, set an
+[ActiveSupport::Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html)
+service object on a pipeline object. New pipeline objects will default to the
 `HTML::Pipeline.default_instrumentation_service` object.
 
 ``` ruby
@@ -222,6 +222,14 @@ instrumentation call.
 ``` ruby
 service.subscribe "call_filter.html_pipeline" do |event, start, ending, transaction_id, payload|
   payload[:filter] #=> "MarkdownFilter"
+end
+```
+
+The full pipeline is also instrumented:
+
+``` ruby
+service.subscribe "call_pipeline.html_pipeline" do |event, start, ending, transaction_id, payload|
+  payload[:filters] #=> ["MarkdownFilter"]
 end
 ```
 

--- a/lib/html/pipeline.rb
+++ b/lib/html/pipeline.rb
@@ -94,10 +94,12 @@ module HTML
       context = @default_context.merge(context)
       context = context.freeze
       result ||= @result_class.new
-      result[:output] =
-        @filters.inject(html) do |doc, filter|
-          perform_filter(filter, doc, context, result)
-        end
+      instrument "call_pipeline.html_pipeline", :filters => @filters.map(&:name) do
+        result[:output] =
+          @filters.inject(html) do |doc, filter|
+            perform_filter(filter, doc, context, result)
+          end
+      end
       result
     end
 

--- a/test/helpers/mocked_instrumentation_service.rb
+++ b/test/helpers/mocked_instrumentation_service.rb
@@ -1,11 +1,15 @@
 class MockedInstrumentationService
   attr_reader :events
-  def initialize(events = [])
+  def initialize(event = nil, events = [])
     @events = events
+    subscribe event
   end
   def instrument(event, payload = nil)
     res = yield
-    events << [event, payload, res]
+    events << [event, payload, res] if @subscribe == event
     res
+  end
+  def subscribe(event)
+    @subscribe = event
   end
 end

--- a/test/html/pipeline_test.rb
+++ b/test/html/pipeline_test.rb
@@ -17,12 +17,24 @@ class HTML::PipelineTest < Test::Unit::TestCase
 
   def test_filter_instrumentation
     service = MockedInstrumentationService.new
+    service.subscribe "call_filter.html_pipeline"
     @pipeline.instrumentation_service = service
     filter("hello")
     event, payload, res = service.events.pop
     assert event, "event expected"
     assert_equal "call_filter.html_pipeline", event
     assert_equal TestFilter.name, payload[:filter]
+  end
+
+  def test_pipeline_instrumentation
+    service = MockedInstrumentationService.new
+    service.subscribe "call_pipeline.html_pipeline"
+    @pipeline.instrumentation_service = service
+    filter("hello")
+    event, payload, res = service.events.pop
+    assert event, "event expected"
+    assert_equal "call_pipeline.html_pipeline", event
+    assert_equal @pipeline.filters.map(&:name), payload[:filters]
   end
 
   def test_default_instrumentation_service


### PR DESCRIPTION
This makes `HTML::Pipeline` compatible with [ActiveSupport::Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) instrumentation.

Shuffles things around a bit but adds instrumenting to every filter call.

@jch I know we talked about putting the instrumentation on the individual filters but I decided to keep it here since I wanted to make it easy to make the instrumentation service object available. The pipeline felt like the right place to put that, and the individual filter wasn't aware of the pipeline object as far as I could see.
