### PR TITLE
Strip contents of <script> tags.

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -35,6 +35,7 @@ module HTML
           div ins del sup sub p ol ul table blockquote dl dt dd
           kbd q samp var hr ruby rt rp li tr td th
         ),
+        :remove_contents => ['script'],
         :attributes => {
           'a' => ['href'],
           'img' => ['src'],

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -44,4 +44,9 @@ class HTML::Pipeline::SanitizationFilterTest < Test::Unit::TestCase
     stuff = '<a href="github-windows://spillthelog">Spill this yo</a> and so on'
     assert_equal stuff, SanitizationFilter.call(stuff).to_s
   end
+
+  def test_script_contents_are_removed
+    orig = '<script>JavaScript!</script>'
+    assert_equal "", SanitizationFilter.call(orig).to_s
+  end
 end


### PR DESCRIPTION
This will turn this:

``` ruby
SanitizationFilter.call('<script>JavaScript!</script>').to_s #=> JavaScript!
```

into this: 

``` ruby
SanitizationFilter.call('<script>JavaScript!</script>').to_s #=> 
```

Dunno if this would be useful for everyone, but for my purposes there aren't any cases where I want to show what is inside a script tag.
