### PR TITLE
New octicon class names

### DIFF
--- a/lib/html/pipeline/toc_filter.rb
+++ b/lib/html/pipeline/toc_filter.rb
@@ -18,7 +18,7 @@ module HTML
           uniq = (headers[name] > 0) ? "-#{headers[name]}" : ''
           headers[name] += 1
           if header_content = node.children.first
-            header_content.add_previous_sibling(%Q{<a name="#{name}#{uniq}" class="anchor" href="##{name}#{uniq}"><span class="mini-icon mini-icon-link"></span></a>})
+            header_content.add_previous_sibling(%Q{<a name="#{name}#{uniq}" class="anchor" href="##{name}#{uniq}"><span class="octicon octicon-link"></span></a>})
           end
         end
         doc


### PR DESCRIPTION
The upcoming release of Octicons has renamed all the icon classes. This updates html-pipeline with the new master icon class `.octicon` and the icon class `.octicon-link`.

cc @rsanheim
