### PR TITLE
Fix the `AutolinkFilter` constant name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ filter.call
 
 * `MentionFilter` - replace `@user` mentions with links
 * `AbsoluteSourceFilter` - replace relative image urls with fully qualified versions
-* `AutoLinkFilter` - auto_linking urls in HTML
+* `AutolinkFilter` - auto_linking urls in HTML
 * `CamoFilter` - replace http image urls with [camo-fied](https://github.com/atmos/camo) https versions
 * `EmailReplyFilter` - util filter for working with emails
 * `EmojiFilter` - everyone loves [emoji](http://www.emoji-cheat-sheet.com/)!


### PR DESCRIPTION
If somebody comes to copy pasta they might be in for a surprise unless they browse the source, this fixes the name of the constant so that people can copy pasta.
