### PR TITLE
Allow passing skip_tags in autolink filter context

### DIFF
--- a/lib/html/pipeline/autolink_filter.rb
+++ b/lib/html/pipeline/autolink_filter.rb
@@ -5,17 +5,21 @@ module HTML
     # HTML Filter for auto_linking urls in HTML.
     #
     # Context options:
-    #   :autolink - boolean whether to autolink urls
-    #   :flags    - additional Rinku flags. See https://github.com/vmg/rinku
+    #   :autolink  - boolean whether to autolink urls
+    #   :skip_tags - HTML tags inside which autolinking will be skipped.
+    #                See Rinku.skip_tags
+    #   :flags     - additional Rinku flags. See https://github.com/vmg/rinku
     #
     # This filter does not write additional information to the context.
     class AutolinkFilter < Filter
       def call
         return html if context[:autolink] == false
+
+        skip_tags = context[:skip_tags]
         flags = 0
         flags |= context[:flags] if context[:flags]
 
-        Rinku.auto_link(html, :urls, nil, %w[a script kbd pre code], flags)
+        Rinku.auto_link(html, :urls, nil, skip_tags, flags)
       end
     end
   end

--- a/test/html/pipeline/autolink_filter_test.rb
+++ b/test/html/pipeline/autolink_filter_test.rb
@@ -19,4 +19,12 @@ class HTML::Pipeline::AutolinkFilterTest < Test::Unit::TestCase
     assert_equal '<p>"<a href="http://github">http://github</a>"</p>',
       AutolinkFilter.to_html('<p>"http://github"</p>', :flags => Rinku::AUTOLINK_SHORT_DOMAINS)
   end
+
+  def test_autolink_skip_tags
+    assert_equal '<code>"http://github.com"</code>',
+      AutolinkFilter.to_html('<code>"http://github.com"</code>')
+
+    assert_equal '<code>"<a href="http://github.com">http://github.com</a>"</code>',
+      AutolinkFilter.to_html('<code>"http://github.com"</code>', :skip_tags => %w(kbd script))
+  end
 end


### PR DESCRIPTION
Enables passing the `skip_tags` argument to Rinku. Defaults to `Rinku.skip_tags`.
