### PR TITLE
TocFilter: keep using the old punctuation stripping on 1.8.7

### DIFF
--- a/lib/html/pipeline/toc_filter.rb
+++ b/lib/html/pipeline/toc_filter.rb
@@ -7,11 +7,13 @@ module HTML
     # eventually generating the Table of Contents itself, with links
     # to each header
     class TableOfContentsFilter < Filter
+      PUNCTUATION_REGEXP = RUBY_VERSION > "1.9" ? /[^\p{Word}\- ]/u : /[^\w\- ]/
+
       def call
         headers = Hash.new(0)
         doc.css('h1, h2, h3, h4, h5, h6').each do |node|
           name = node.text.downcase
-          name.gsub!(/[^\p{Word}\- ]/u, '') # remove punctuation
+          name.gsub!(PUNCTUATION_REGEXP, '') # remove punctuation
           name.gsub!(' ', '-') # replace spaces with dash
 
           uniq = (headers[name] > 0) ? "-#{headers[name]}" : ''

--- a/test/html/pipeline/toc_filter_test.rb
+++ b/test/html/pipeline/toc_filter_test.rb
@@ -54,5 +54,5 @@ class HTML::Pipeline::TableOfContentsFilterTest < Test::Unit::TestCase
                  rendered_h1s[0]
     assert_equal "<h1>\n<a name=\"%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\" class=\"anchor\" href=\"#%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\"><span class=\"octicon octicon-link\"></span></a>Русский</h1>",
                  rendered_h1s[1]
-  end
+  end if RUBY_VERSION > "1.9" # not sure how to make this work on 1.8.7
 end


### PR DESCRIPTION
The UTF regexp doesn't seem to work correctly under 1.8.7 and causes existing tests to fail. We don't really care about fixing this case for 1.8.7 but we don't want the gem to be unusable, so we'll just special case it for now.

/cc @jch @brianmario
