### PR TITLE
Fix wrong class name at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ HtmlEmailPipeline = Pipeline.new [
 
 # Just emoji.
 EmojiPipeline = Pipeline.new [
-  HTMLInputFilter,
+  PlainTextInputFilter,
   EmojiFilter
 ], context
 ```


### PR DESCRIPTION
`HTMLInputFilter` is not exist.
