### PR TITLE
Allow ActiveSupport > 4 for ruby > 1.9

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "sanitize",        RUBY_VERSION < "1.9.2" ? [">= 2", "< 2.0.4"] : "~> 2.0"
   gem.add_dependency "rinku",           "~> 1.7"
   gem.add_dependency "escape_utils",    "~> 0.3"
-  gem.add_dependency "activesupport",   RUBY_VERSION < "1.9.3" ? [">= 2", "< 4"] : ">= 2"
+  gem.add_dependency "activesupport",   RUBY_VERSION < "1.9" ? [">= 2", "< 4"] : ">= 2"
 
   gem.add_development_dependency "github-linguist", "~> 2.6.2"
 end


### PR DESCRIPTION
Possible fix for #76

previously < 1.9.3, now < 1.9. Should fix #76
