### PR TITLE
Move activesupport to a development dependency

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "sanitize",        RUBY_VERSION < "1.9.2" ? [">= 2", "< 2.0.4"] : "~> 2.0"
   gem.add_dependency "rinku",           "~> 1.7"
   gem.add_dependency "escape_utils",    "~> 0.3"
-  gem.add_dependency "activesupport",   RUBY_VERSION < "1.9.3" ? [">= 2", "< 4"] : ">= 2"
 
+  gem.add_development_dependency "activesupport", RUBY_VERSION < "1.9.3" ? [">= 2", "< 4"] : ">= 2"
   gem.add_development_dependency "github-linguist", "~> 2.6.2"
 end


### PR DESCRIPTION
It's used for instrumentation, but the requirement is only an object
that supports an `ActiveSupport::Notification` compatible interface. See
[this section of the README](https://github.com/jch/html-pipeline#instrumenting)
for details.
