### PR TITLE
Guard against nil node replacement results

### DIFF
--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -19,11 +19,12 @@ module HTML
           html = highlight_with_timeout_handling(lexer, text)
           next if html.nil?
 
-          node = node.replace(html).first
-          klass = node["class"]
-          klass = [klass, "highlight-#{lang}"].compact.join " "
+          if (node = node.replace(html).first)
+            klass = node["class"]
+            klass = [klass, "highlight-#{lang}"].compact.join " "
 
-          node["class"] = klass
+            node["class"] = klass
+          end
         end
         doc
       end


### PR DESCRIPTION
I introduced a bug in #81 causing `SyntaxHighlightFilter` to explode if a node replacement returns `nil`. This PR guards against it.
