### PR TITLE
use xml_mini extracted from activesupport

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "sanitize",        RUBY_VERSION < "1.9.2" ? [">= 2", "< 2.0.4"] : "~> 2.0"
   gem.add_dependency "rinku",           "~> 1.7"
   gem.add_dependency "escape_utils",    "~> 0.3"
+  gem.add_dependency "activesupport",   RUBY_VERSION < "1.9.3" ? [">= 2", "< 4"] : ">= 2"
 
-  gem.add_development_dependency "activesupport", RUBY_VERSION < "1.9.3" ? [">= 2", "< 4"] : ">= 2"
   gem.add_development_dependency "github-linguist", "~> 2.6.2"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'html/pipeline'
 require 'test/unit'
 
+require 'active_support/core_ext/string'
 require 'active_support/core_ext/object/try'
 
 module TestHelpers


### PR DESCRIPTION
Switch to xml_mini gem to avoid runtime dependency on activesupport.
- add xml_mini as dependency since it's required to load html-pipeline
- activesupport kept as development dependency for use in tests
