### PR TITLE
Add link_attr option to Autolink filter

### DIFF
--- a/lib/html/pipeline/autolink_filter.rb
+++ b/lib/html/pipeline/autolink_filter.rb
@@ -6,6 +6,7 @@ module HTML
     #
     # Context options:
     #   :autolink  - boolean whether to autolink urls
+    #   :link_attr - HTML attributes for the link that will be generated
     #   :skip_tags - HTML tags inside which autolinking will be skipped.
     #                See Rinku.skip_tags
     #   :flags     - additional Rinku flags. See https://github.com/vmg/rinku
@@ -19,7 +20,7 @@ module HTML
         flags = 0
         flags |= context[:flags] if context[:flags]
 
-        Rinku.auto_link(html, :urls, nil, skip_tags, flags)
+        Rinku.auto_link(html, :urls, context[:link_attr], skip_tags, flags)
       end
     end
   end

--- a/test/html/pipeline/autolink_filter_test.rb
+++ b/test/html/pipeline/autolink_filter_test.rb
@@ -15,6 +15,11 @@ class HTML::Pipeline::AutolinkFilterTest < Test::Unit::TestCase
       AutolinkFilter.to_html('<p>"http://www.github.com"</p>', :autolink => false)
   end
 
+  def test_autolink_link_attr
+    assert_equal '<p>"<a href="http://www.github.com" target="_blank">http://www.github.com</a>"</p>',
+      AutolinkFilter.to_html('<p>"http://www.github.com"</p>', :link_attr => 'target="_blank"')
+  end
+
   def test_autolink_flags
     assert_equal '<p>"<a href="http://github">http://github</a>"</p>',
       AutolinkFilter.to_html('<p>"http://github"</p>', :flags => Rinku::AUTOLINK_SHORT_DOMAINS)


### PR DESCRIPTION
Let's you add things like `target="_blank"` to links if you want to through the `link_attr` option just like Rinku allows.
