### PR TITLE
Camo Everything

### DIFF
--- a/lib/html/pipeline/camo_filter.rb
+++ b/lib/html/pipeline/camo_filter.rb
@@ -20,12 +20,10 @@ module HTML
       # go through the github asset proxy.
       def call
         doc.search("img").each do |element|
-          next if element['src'].nil?
-          src = element['src'].strip
-          src = src.sub(%r!^http://github.com!, 'https://github.com')
-
           next if context[:disable_asset_proxy]
-          element['src'] = asset_proxy_url(src)
+          if src = element['src']
+            element['src'] = asset_proxy_url(src)
+          end
         end
         doc
       end

--- a/test/html/pipeline/camo_filter_test.rb
+++ b/test/html/pipeline/camo_filter_test.rb
@@ -18,12 +18,6 @@ class HTML::Pipeline::CamoFilterTest < Test::Unit::TestCase
       CamoFilter.call(orig, @options).to_s
   end
 
-  def test_rewrites_dotcom_image_urls
-    orig = %(<p><img src="http://github.com/img.png"></p>)
-    assert_equal "<p><img src=\"https://github.com/img.png\"></p>",
-      CamoFilter.call(orig, @options).to_s
-  end
-
   def test_camouflaging_https_image_urls
     orig = %(<p><img src="https://foo.com/img.png"></p>)
     assert_includes 'img src="' + @asset_proxy_url,


### PR DESCRIPTION
Camo's all images including `https`.

Removed `http/https://github.com` image rewriting. Those shouldn't but linked to in GFM. So no one ought to be doing that. They should be using github helpers so they point to our CDN. Also, this would point them to a CDN through camo. Fewer edge cases.

/cc @jch @atmos
