### PR TITLE
Allow customization of allowed <a href> URL schemes

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -20,7 +20,8 @@ module HTML
     #                     class or a custom sanitize options hash.
     #   :anchor_schemes - The URL schemes to allow in <a href> attributes. The
     #                     default set is provided in the ANCHOR_SCHEMES
-    #                     constant in this class.
+    #                     constant in this class. If passed, this overrides any
+    #                     schemes specified in the whitelist configuration.
     #
     # This filter does not write additional information to the context.
     class SanitizationFilter < Filter
@@ -110,17 +111,13 @@ module HTML
       # The whitelist to use when sanitizing. This can be passed in the context
       # hash to the filter but defaults to WHITELIST constant value above.
       def whitelist
-        whitelist = (context[:whitelist] || WHITELIST).dup
+        whitelist = context[:whitelist] || WHITELIST
+        anchor_schemes = context[:anchor_schemes]
+        return whitelist unless anchor_schemes
+        whitelist = whitelist.dup
         whitelist[:protocols] = (whitelist[:protocols] || {}).dup
         whitelist[:protocols]['a'] = (whitelist[:protocols]['a'] || {}).merge('href' => anchor_schemes)
         whitelist
-      end
-
-      # The schemes to allow in <a href> attributes. This can be passed in the
-      # context hash to the filter but defaults to ANCHOR_SCHEMES constant
-      # value above.
-      def anchor_schemes
-        context[:anchor_schemes] || ANCHOR_SCHEMES
       end
     end
   end

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -77,6 +77,18 @@ class HTML::Pipeline::SanitizationFilterTest < Test::Unit::TestCase
     assert_equal '<a href="something-weird://heyyy">Wat</a> is this', html
   end
 
+  def test_uses_anchor_schemes_from_whitelist_when_not_separately_specified
+    stuff  = '<a href="something-weird://heyyy">Wat</a> is this'
+    whitelist = {
+      :elements   => ['a'],
+      :attributes => {'a' => ['href']},
+      :protocols  => {'a' => {'href' => ['something-weird']}}
+    }
+    filter = SanitizationFilter.new(stuff, {:whitelist => whitelist})
+    html   = filter.call.to_s
+    assert_equal stuff, html
+  end
+
   def test_whitelist_contains_default_anchor_schemes
     assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
   end


### PR DESCRIPTION
A new context parameter, `:anchor_schemes`, can be used to override the default list of allowed schemes.

Note that this means that these schemes are no longer configurable via the `:whitelist` context parameter. They can only be controlled via `:anchor_schemes`.
