### PR TITLE
Stop using deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/html/pipeline/camo_filter.rb
+++ b/lib/html/pipeline/camo_filter.rb
@@ -56,8 +56,7 @@ module HTML
 
       # Private: calculate the HMAC digest for a image source URL.
       def asset_url_hash(url)
-        digest = OpenSSL::Digest.new('sha1')
-        OpenSSL::HMAC.hexdigest(digest, asset_proxy_secret_key, url)
+        OpenSSL::HMAC.hexdigest('sha1', asset_proxy_secret_key, url)
       end
 
       # Private: Return true if asset proxy filter should be enabled


### PR DESCRIPTION
`OpenSSL::Digest::Digest` is deprecated as of Ruby 2.1 and has been discouraged since Ruby 1.8.7.

See: http://goo.gl/E4O0Oq

Fixes a deprecation warning in Ruby 2.1:

``` bash
Digest::Digest is deprecated; use Digest
```
