### PR TITLE
Add protocols we allow in wikis

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -37,7 +37,8 @@ module HTML
       TABLE_SECTIONS = Set.new(%w(thead tbody tfoot).freeze)
 
       # These schemes are the only ones allowed in <a href> attributes by default.
-      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac'].freeze
+      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'ftp', 'irc', 'apt',
+        'github-windows', 'github-mac'].freeze
 
       # The main sanitization whitelist. Only these elements and attributes are
       # allowed through by default.

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -90,7 +90,7 @@ class HTML::Pipeline::SanitizationFilterTest < Test::Unit::TestCase
   end
 
   def test_whitelist_contains_default_anchor_schemes
-    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'ftp', 'irc', 'apt', 'github-windows', 'github-mac']
   end
 
   def test_whitelist_from_full_constant
@@ -101,7 +101,7 @@ class HTML::Pipeline::SanitizationFilterTest < Test::Unit::TestCase
   end
 
   def test_exports_default_anchor_schemes
-    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', :relative, 'ftp', 'irc', 'apt', 'github-windows', 'github-mac']
   end
 
   def test_script_contents_are_removed


### PR DESCRIPTION
This updates the anchor schemes to include `ftp`, `irc` and `apt`, which we've allow in wikis on GitHub for a while.
