### PR TITLE
EmailReplyFilter depends on EmailReplyParser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,13 @@ group :development do
 end
 
 group :test do
-  gem "rinku",            "~> 1.7",   :require => false
-  gem "gemoji",           "~> 1.0",   :require => false
-  gem "RedCloth",         "~> 4.2.9", :require => false
-  gem "escape_utils",     "~> 0.3",   :require => false
-  gem "github-linguist",  "~> 2.6.2", :require => false
-  gem "github-markdown",  "~> 0.5",   :require => false
+  gem "rinku",              "~> 1.7",   :require => false
+  gem "gemoji",             "~> 1.0",   :require => false
+  gem "RedCloth",           "~> 4.2.9", :require => false
+  gem "escape_utils",       "~> 0.3",   :require => false
+  gem "github-linguist",    "~> 2.6.2", :require => false
+  gem "github-markdown",    "~> 0.5",   :require => false
+  gem "email_reply_parser", "~> 0.5",   :require => false
 
   if RUBY_VERSION < "1.9.2"
     gem "sanitize", ">= 2", "< 2.0.4", :require => false

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ gem 'github-linguist'
 ```
 
 * `AutolinkFilter` - `rinku`
-* `EmailReplyFilter` - `escape_utils`
+* `EmailReplyFilter` - `escape_utils`, `email_reply_parser`
 * `EmojiFilter` - `gemoji`
 * `MarkdownFilter` - `github-markdown`
 * `PlainTextInputFilter` - `escape_utils`

--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -4,6 +4,12 @@ rescue LoadError => _
   abort "Missing dependency 'escape_utils' for EmailReplyFilter. See README.md for details."
 end
 
+begin
+  require "email_reply_parser"
+rescue LoadError => _
+  abort "Missing dependency 'email_reply_parser' for EmailReplyFilter. See README.md for details."
+end
+
 module HTML
   class Pipeline
     # HTML Filter that converts email reply text into an HTML DocumentFragment.


### PR DESCRIPTION
Make sure we require it and inform the user that the gem should also be bundled if they want to use it.

Fixes #107
