### PR TITLE
Use id attribute instead of name for ToC

### DIFF
--- a/lib/html/pipeline/toc_filter.rb
+++ b/lib/html/pipeline/toc_filter.rb
@@ -1,6 +1,6 @@
 module HTML
   class Pipeline
-    # HTML filter that adds a 'name' attribute to all headers
+    # HTML filter that adds a 'id' attribute to all headers
     # in a document, so they can be accessed from a table of contents.
     #
     # Generates the Table of Contents, with links to each header.
@@ -21,7 +21,7 @@ module HTML
     #  result[:toc]
     #  # => "<ul class=\"section-nav\">\n<li><a href=\"#ice-cube\">...</li><ul>"
     #  result[:output].to_s
-    #  # => "<h1>\n<a name=\"ice-cube\" class=\"anchor\" href=\"#ice-cube\">..."
+    #  # => "<h1>\n<a id=\"ice-cube\" class=\"anchor\" href=\"#ice-cube\">..."
     class TableOfContentsFilter < Filter
       PUNCTUATION_REGEXP = RUBY_VERSION > "1.9" ? /[^\p{Word}\- ]/u : /[^\w\- ]/
 
@@ -31,15 +31,16 @@ module HTML
         headers = Hash.new(0)
         doc.css('h1, h2, h3, h4, h5, h6').each do |node|
           text = node.text
-          name = text.downcase
-          name.gsub!(PUNCTUATION_REGEXP, '') # remove punctuation
-          name.gsub!(' ', '-') # replace spaces with dash
+          id = text.downcase
+          id.gsub!(PUNCTUATION_REGEXP, '') # remove punctuation
+          id.gsub!(' ', '-') # replace spaces with dash
+          id = EscapeUtils.escape_uri(id)
 
-          uniq = (headers[name] > 0) ? "-#{headers[name]}" : ''
-          headers[name] += 1
+          uniq = (headers[id] > 0) ? "-#{headers[id]}" : ''
+          headers[id] += 1
           if header_content = node.children.first
-            result[:toc] << %Q{<li><a href="##{name}#{uniq}">#{text}</a></li>\n}
-            header_content.add_previous_sibling(%Q{<a name="#{name}#{uniq}" class="anchor" href="##{name}#{uniq}"><span class="octicon octicon-link"></span></a>})
+            result[:toc] << %Q{<li><a href="##{id}#{uniq}">#{text}</a></li>\n}
+            header_content.add_previous_sibling(%Q{<a id="#{id}#{uniq}" class="anchor" href="##{id}#{uniq}"><span class="octicon octicon-link"></span></a>})
           end
         end
         result[:toc] = %Q{<ul class="section-nav">\n#{result[:toc]}</ul>} unless result[:toc].empty?

--- a/test/html/pipeline/toc_filter_test.rb
+++ b/test/html/pipeline/toc_filter_test.rb
@@ -17,7 +17,7 @@ class HTML::Pipeline::TableOfContentsFilterTest < Test::Unit::TestCase
 
   def test_anchors_are_added_properly
     orig = %(<h1>Ice cube</h1><p>Will swarm on any motherfucker in a blue uniform</p>)
-    assert_includes '<a name=', TocFilter.call(orig).to_s
+    assert_includes '<a id=', TocFilter.call(orig).to_s
   end
 
   def test_toc_list_added_properly
@@ -101,9 +101,9 @@ class HTML::Pipeline::TableOfContentsFilterTest < Test::Unit::TestCase
 
       rendered_h1s = TocFilter.call(orig).search('h1').map(&:to_s)
 
-      assert_equal "<h1>\n<a name=\"%E6%97%A5%E6%9C%AC%E8%AA%9E\" class=\"anchor\" href=\"#%E6%97%A5%E6%9C%AC%E8%AA%9E\"><span class=\"octicon octicon-link\"></span></a>日本語</h1>",
+      assert_equal "<h1>\n<a id=\"%E6%97%A5%E6%9C%AC%E8%AA%9E\" class=\"anchor\" href=\"#%E6%97%A5%E6%9C%AC%E8%AA%9E\"><span class=\"octicon octicon-link\"></span></a>日本語</h1>",
                    rendered_h1s[0]
-      assert_equal "<h1>\n<a name=\"%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\" class=\"anchor\" href=\"#%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\"><span class=\"octicon octicon-link\"></span></a>Русский</h1>",
+      assert_equal "<h1>\n<a id=\"%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\" class=\"anchor\" href=\"#%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\"><span class=\"octicon octicon-link\"></span></a>Русский</h1>",
                    rendered_h1s[1]
     end
 


### PR DESCRIPTION
The `name` attribute is no longer considered a global attribute or part of the `a` element as of the XHTML/HTML5 spec. `id` has replaced this deprecated usage of the `name` attribute. `name` is now reserved only for "form controls".

> Note that in XHTML 1.0, the name attribute of these elements is formally deprecated, and will be removed in a subsequent version of XHTML. - http://www.w3.org/TR/xhtml1/#h-4.10

Related
- #64 cc @jakedouglas @brianmario
- The `a` element - http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element
- The `id` attribute - http://www.w3.org/TR/html5/dom.html#the-id-attribute
- The `name` attribute - http://www.w3.org/TR/html5/forms.html#naming-form-controls:-the-name-attribute

cc @jch @raganwald @mislav
