### PR TITLE
Add compatibility with gemoji v2

### DIFF
--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -14,10 +14,6 @@ module HTML
     #   :asset_root (required) - base url to link to emoji sprite
     #   :asset_path (optional) - url path to link to emoji sprite. :file_name can be used as a placeholder for the sprite file name. If no asset_path is set "emoji/:file_name" is used.
     class EmojiFilter < Filter
-      # Build a regexp that matches all valid :emoji: names.
-      emoji_names = Emoji.respond_to?(:all) ? Emoji.all.map(&:name) : Emoji.names
-      EmojiPattern = /:(#{emoji_names.map { |name| Regexp.escape(name) }.join('|')}):/
-
       def call
         doc.search('text()').each do |node|
           content = node.to_html
@@ -44,7 +40,7 @@ module HTML
       def emoji_image_filter(text)
         return text unless text.include?(':')
 
-        text.gsub EmojiPattern do |match|
+        text.gsub(emoji_pattern) do |match|
           name = $1
           "<img class='emoji' title=':#{name}:' alt=':#{name}:' src='#{emoji_url(name)}' height='20' width='20' align='absmiddle' />"
         end
@@ -63,17 +59,10 @@ module HTML
       # :file_name can be used in the asset_path as a placeholder for the sprite file name. If no asset_path is set in the context "emoji/:file_name" is used.
       # Returns the context's asset_path or the default path if no context asset_path is given.
       def asset_path(name)
-        if Emoji.respond_to?(:find_by_alias)
-          emoji = Emoji.find_by_alias(name)
-          image_filename = emoji.image_filename
-        else
-          image_filename = "#{::CGI.escape(name)}.png"
-        end
-
         if context[:asset_path]
-          context[:asset_path].gsub(":file_name", image_filename)
+          context[:asset_path].gsub(":file_name", emoji_filename(name))
         else
-          File.join("emoji", image_filename)
+          File.join("emoji", emoji_filename(name))
         end
       end
 
@@ -81,6 +70,35 @@ module HTML
 
       def emoji_url(name)
         File.join(asset_root, asset_path(name))
+      end
+
+      # Build a regexp that matches all valid :emoji: names.
+      def self.emoji_pattern
+        @emoji_pattern ||= /:(#{emoji_names.map { |name| Regexp.escape(name) }.join('|')}):/
+      end
+
+      def emoji_pattern
+        self.class.emoji_pattern
+      end
+
+      # Detect gemoji v2 which has a new API
+      # https://github.com/jch/html-pipeline/pull/129
+      if Emoji.respond_to?(:all)
+        def self.emoji_names
+          Emoji.all.map(&:aliases).flatten.sort
+        end
+
+        def emoji_filename(name)
+          Emoji.find_by_alias(name).image_filename
+        end
+      else
+        def self.emoji_names
+          Emoji.names
+        end
+
+        def emoji_filename(name)
+          "#{::CGI.escape(name)}.png"
+        end
       end
     end
   end


### PR DESCRIPTION
This adds compatibility with upcoming gemoji v2 release that has an API completely incompatible with the previous one. I opted for supporting both APIs here because it was easy to do feature detection and so that html-pipeline users can update this library without having to necessarily upgrade gemoji in their apps.

The Gemfile and tests are still configured to use gemoji v1.x for the time being since test output (image names, to be precise) can be different when running against gemoji v2.

/cc @aroben @josh
