### PR TITLE
Remove RUBY_VERSION conditionals from gemspec

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^test})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "nokogiri",      RUBY_VERSION < "1.9.2" ? [">= 1.4", "< 1.6"] : "~> 1.4"
-  gem.add_dependency "activesupport", RUBY_VERSION < "1.9.3" ? [">= 2", "< 4"] : ">= 2"
+  gem.add_dependency "nokogiri", "~> 1.4"
+  gem.add_dependency "activesupport", ">= 2"
 
   gem.post_install_message = <<msg
 -------------------------------------------------


### PR DESCRIPTION
Remove the useless conditionals added in ae1f3c828cccd2b5ebf0678ea3edc2bcca10c9f3 since gemspec is turned into a static one at gem publish time, so the version constraints will be adjusted to whatever Ruby version the gem was _published_ with, not the one that will eventually run the gem.

If someone is still running Ruby 1.8 or 1.9.2, it's their responsibility to adjust their project's Gemfile to prevent Nokogiri or Active Support upgrading to an incompatible version.

/cc @jch
