### PR TITLE
Remove ActiveSupport try() dependency

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@ require 'html/pipeline'
 require 'minitest/autorun'
 
 require 'active_support/core_ext/string'
-require 'active_support/core_ext/object/try'
 
 module TestHelpers
   # Asserts that two html fragments are equivalent. Attribute order


### PR DESCRIPTION
- try() was removed in 70c7ac5b8874a4da6021e892ce573d3579a6f8f9,
  so no need to require
