### PR TITLE
adding "details" to tag whitelist

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -57,7 +57,7 @@ module HTML
                     'border', 'cellpadding', 'cellspacing', 'char',
                     'charoff', 'charset', 'checked', 'cite',
                     'clear', 'cols', 'colspan', 'color',
-                    'compact', 'coords', 'datetime', 'dir',
+                    'compact', 'coords', 'datetime', 'details', 'dir',
                     'disabled', 'enctype', 'for', 'frame',
                     'headers', 'height', 'hreflang',
                     'hspace', 'ismap', 'label', 'lang',


### PR DESCRIPTION
Apologies if this pull request is to the wrong branch, or in any fashion inappropriate.  It's to support this feature request: https://github.com/jch/html-pipeline/issues/138  which comes from my desire to use summary/detail tag combinations in github markdown.  I'm assuming that if the summary tag is acceptable, then the detail tag is okay too?

I've run the tests locally and they all pass (for ruby-2.1.2).  Hoping that this can get into a new version and then into github markup so that everyone can enjoy details/summary goodness in their Github READMEs :-)

I've tested them against all the supported rubies in your submissions guidelines.  All good, although some of those rubies are not the latest security releases: 

ree-1.8.7-2011.03 1.9.2-p290 1.9.3-p429 2.0.0-p247

did you want to upgrade your submissions guidelines in that regard?
