### PR TITLE
Use id instead of name for TableOfContentsFilter

### DIFF
--- a/lib/html/pipeline/toc_filter.rb
+++ b/lib/html/pipeline/toc_filter.rb
@@ -39,7 +39,7 @@ module HTML
           headers[id] += 1
           if header_content = node.children.first
             result[:toc] << %Q{<li><a href="##{id}#{uniq}">#{text}</a></li>\n}
-            header_content.add_previous_sibling(%Q{<a id="#{id}#{uniq}" class="anchor" href="##{id}#{uniq}"><span class="octicon octicon-link"></span></a>})
+            header_content.add_previous_sibling(%Q{<a id="#{id}#{uniq}" class="anchor" href="##{id}#{uniq}" aria-hidden="true"><span class="octicon octicon-link"></span></a>})
           end
         end
         result[:toc] = %Q{<ul class="section-nav">\n#{result[:toc]}</ul>} unless result[:toc].empty?

--- a/test/html/pipeline/toc_filter_test.rb
+++ b/test/html/pipeline/toc_filter_test.rb
@@ -35,6 +35,12 @@ class HTML::Pipeline::TableOfContentsFilterTest < Minitest::Test
     assert_includes result, '"mc-ren"'
   end
 
+  def test_anchors_have_aria_hidden
+    orig = "<h1>Straight Outta Compton</h1>"
+    result = TocFilter.call(orig).to_s
+    assert_includes result, 'aria-hidden="true"'
+  end
+
   def test_toc_hrefs_have_sane_values
     @orig = %(<h1>Dr Dre</h1><h1>Ice Cube</h1><h1>Eazy-E</h1><h1>MC Ren</h1>)
     assert_includes toc, '"#dr-dre"'
@@ -101,9 +107,9 @@ class HTML::Pipeline::TableOfContentsFilterTest < Minitest::Test
 
       rendered_h1s = TocFilter.call(orig).search('h1').map(&:to_s)
 
-      assert_equal "<h1>\n<a id=\"日本語\" class=\"anchor\" href=\"#%E6%97%A5%E6%9C%AC%E8%AA%9E\"><span class=\"octicon octicon-link\"></span></a>日本語</h1>",
+      assert_equal "<h1>\n<a id=\"日本語\" class=\"anchor\" href=\"#%E6%97%A5%E6%9C%AC%E8%AA%9E\" aria-hidden=\"true\"><span class=\"octicon octicon-link\"></span></a>日本語</h1>",
                    rendered_h1s[0]
-      assert_equal "<h1>\n<a id=\"Русский\" class=\"anchor\" href=\"#%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\"><span class=\"octicon octicon-link\"></span></a>Русский</h1>",
+      assert_equal "<h1>\n<a id=\"Русский\" class=\"anchor\" href=\"#%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\" aria-hidden=\"true\"><span class=\"octicon octicon-link\"></span></a>Русский</h1>",
                    rendered_h1s[1]
     end
 


### PR DESCRIPTION
Closes #135

I also added the [aria-hidden](http://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden) attribute, which tells assistive devices that this element is not actually visible. We already set this on GitHub, so I thought it would make sense to be included upstream.

/cc @jch @josh 
