### PR TITLE
Don't check twice if there is a ':' in content (EmojiFilter)

### DIFF
--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -17,7 +17,7 @@ module HTML
       def call
         doc.search('text()').each do |node|
           content = node.to_html
-          next if !content.include?(':')
+          next unless content.include?(':')
           next if has_ancestor?(node, %w(pre code))
           html = emoji_image_filter(content)
           next if html == content
@@ -38,8 +38,6 @@ module HTML
       #
       # Returns a String with :emoji: replaced with images.
       def emoji_image_filter(text)
-        return text unless text.include?(':')
-
         text.gsub(emoji_pattern) do |match|
           name = $1
           "<img class='emoji' title=':#{name}:' alt=':#{name}:' src='#{emoji_url(name)}' height='20' width='20' align='absmiddle' />"


### PR DESCRIPTION
Second check if there is a `:` in a text is not needed, since it's already done before.
