### PR TITLE
Do a second xpath search to match elements without parent node

### DIFF
--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -15,7 +15,7 @@ module HTML
     #   :asset_path (optional) - url path to link to emoji sprite. :file_name can be used as a placeholder for the sprite file name. If no asset_path is set "emoji/:file_name" is used.
     class EmojiFilter < Filter
       def call
-        doc.search('text()').each do |node|
+        doc.xpath('.//text() | text()').each do |node|
           content = node.to_html
           next if !content.include?(':')
           next if has_ancestor?(node, %w(pre code))

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -8,6 +8,12 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
     doc = filter.call
     assert_match "https://foo.com/emoji/shipit.png", doc.search('img').attr('src').value
   end
+
+  def test_emojify_on_string
+    filter = EmojiFilter.new(":shipit:", {:asset_root => 'https://foo.com'})
+    doc = filter.call
+    assert_match "https://foo.com/emoji/shipit.png", doc.search('img').attr('src').value
+  end
   
   def test_uri_encoding
     filter = EmojiFilter.new("<p>:+1:</p>", {:asset_root => 'https://foo.com'})


### PR DESCRIPTION
Hey @jch, it turned out to be not that easy.

~~However I came up with a solution which needs a second `xpath` search. I changed the first also, because we don't need a `css` search. (`search` internally determines if we do a `xpath` or `css` search). To avoid creating a third list (happens for `(doc.xpath('.//text()') + doc.xpath('text()).each`), I process the nodes in two blocks. Therefore I factored out the processing steps in order to don't violate `DRY`.~~

**Edit**: I came up with a more elegant solution. Lets use the union operator to merge to queries.

One other possibility would be to ensure, that there is always a node. Since this would affect other filters also, I din't bring this solution. Anyway, this fold be the following:

``` ruby
def self.parse(document_or_html)
  document_or_html ||= ''
  if document_or_html.is_a?(String)
    DocumentFragment.parse("<div>#{document_or_html}</div>")
  else
    document_or_html
  end
end
```
