### PR TITLE
Search for text nodes on DocumentFragments without root tags

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -62,7 +62,7 @@ module HTML
       def call
         result[:mentioned_usernames] ||= []
 
-        doc.search('text()').each do |node|
+        search_text_nodes(doc).each do |node|
           content = node.to_html
           next if !content.include?('@')
           next if has_ancestor?(node, IGNORE_PARENTS)

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -15,7 +15,7 @@ module HTML
     #   :asset_path (optional) - url path to link to emoji sprite. :file_name can be used as a placeholder for the sprite file name. If no asset_path is set "emoji/:file_name" is used.
     class EmojiFilter < Filter
       def call
-        doc.search('text()').each do |node|
+        search_text_nodes(doc).each do |node|
           content = node.to_html
           next if !content.include?(':')
           next if has_ancestor?(node, %w(pre code))

--- a/lib/html/pipeline/filter.rb
+++ b/lib/html/pipeline/filter.rb
@@ -59,6 +59,13 @@ module HTML
         @doc ||= parse_html(html)
       end
 
+      # Searches a Nokogiri::HTML::DocumentFragment for text nodes. If no elements
+      # are found, a second search without root tags is invoked.
+      def search_text_nodes(doc)
+        nodes = doc.xpath('.//text()')
+        nodes.empty? ? doc.xpath('text()') : nodes
+      end
+
       # The String representation of the document. If a DocumentFragment was
       # provided to the Filter, it is serialized into a String when this method is
       # called.

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -8,6 +8,12 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
     doc = filter.call
     assert_match "https://foo.com/emoji/shipit.png", doc.search('img').attr('src').value
   end
+
+  def test_emojify_on_string
+    filter = EmojiFilter.new(":shipit:", {:asset_root => 'https://foo.com'})
+    doc = filter.call
+    assert_match "https://foo.com/emoji/shipit.png", doc.search('img').attr('src').value
+  end
   
   def test_uri_encoding
     filter = EmojiFilter.new("<p>:+1:</p>", {:asset_root => 'https://foo.com'})


### PR DESCRIPTION
Hi @jch 

I came up with a second solution for fixing #133. It simply tries a second search for text nodes, if the original search doesn't find any node. Since the second search is only invoked, if the first one doesn't find any node, performance should not change much.
