### PR TITLE
<tt> tags are not skipped by EmojiFilter

### DIFF
--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -18,7 +18,7 @@ module HTML
         search_text_nodes(doc).each do |node|
           content = node.to_html
           next unless content.include?(':')
-          next if has_ancestor?(node, %w(pre code))
+          next if has_ancestor?(node, %w(pre code tt))
           html = emoji_image_filter(content)
           next if html == content
           node.replace(html)

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -33,4 +33,25 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
     doc = filter.call
     assert_match "https://foo.com/%2B1.png", doc.search('img').attr('src').value
   end
+
+  def test_not_emojify_in_code_tags
+    body = "<code>:shipit:</code>"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com'})
+    doc = filter.call
+    assert_equal body, doc.to_html
+  end
+
+  def test_not_emojify_in_tt_tags
+    body = "<tt>:shipit:</tt>"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com'})
+    doc = filter.call
+    assert_equal body, doc.to_html
+  end
+
+  def test_not_emojify_in_pre_tags
+    body = "<pre>:shipit:</pre>"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com'})
+    doc = filter.call
+    assert_equal body, doc.to_html
+  end
 end


### PR DESCRIPTION
The rest2html command in github/markup outputs HTML4, so it wraps rst inline literals with `<tt>` instead of `<code>`. The emoji filter doesn't recognize `<tt>` as a tag that contains literal content, and emoji are substituted where they shouldn't be. 

Toy example: https://github.com/moskvax/test/tree/master/test
Real example: https://github.com/mpv-player/mpv/blob/master/DOCS/man/vf.rst
