### PR TITLE
Use gsub! instead of gsub

### DIFF
--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -17,7 +17,7 @@ module HTML
     class MarkdownFilter < TextFilter
       def initialize(text, context = nil, result = nil)
         super text, context, result
-        @text = @text.gsub "\r", ''
+        @text.gsub! "\r", ""
       end
 
       # Convert Markdown to HTML using the best available implementation


### PR DESCRIPTION
- Be more ruby-ish and use `gsub!` instead of `gsub` because it's assigned to the same variable
- Use consistent string quotes in same function call
