### PR TITLE
Objects to encapsulate whitelist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :test do
   else
     gem "sanitize", "~> 2.0",          :require => false
   end
+  gem "sanitize-whitelist",            :require => false, :github => "bkeepers/sanitize-whitelist"
 
   if RUBY_VERSION < "1.9.3"
     gem "activesupport", ">= 2", "< 4"

--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -1,5 +1,6 @@
 begin
   require "sanitize"
+  require "sanitize/whitelist"
 rescue LoadError => _
   abort "Missing dependency 'sanitize' for SanitizationFilter. See README.md for details."
 end
@@ -25,98 +26,85 @@ module HTML
     #
     # This filter does not write additional information to the context.
     class SanitizationFilter < Filter
-      LISTS     = Set.new(%w(ul ol).freeze)
-      LIST_ITEM = 'li'.freeze
-
-      # List of table child elements. These must be contained by a <table> element
-      # or they are not allowed through. Otherwise they can be used to break out
-      # of places we're using tables to contain formatted user content (like pull
-      # request review comments).
-      TABLE_ITEMS = Set.new(%w(tr td th).freeze)
-      TABLE = 'table'.freeze
-      TABLE_SECTIONS = Set.new(%w(thead tbody tfoot).freeze)
-
       # These schemes are the only ones allowed in <a href> attributes by default.
       ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac'].freeze
 
       # The main sanitization whitelist. Only these elements and attributes are
       # allowed through by default.
-      WHITELIST = {
-        :elements => %w(
-          h1 h2 h3 h4 h5 h6 h7 h8 br b i strong em a pre code img tt
-          div ins del sup sub p ol ul table thead tbody tfoot blockquote
-          dl dt dd kbd q samp var hr ruby rt rp li tr td th s strike
-        ),
-        :remove_contents => ['script'],
-        :attributes => {
-          'a' => ['href'],
-          'img' => ['src'],
-          'div' => ['itemscope', 'itemtype'],
-          :all  => ['abbr', 'accept', 'accept-charset',
-                    'accesskey', 'action', 'align', 'alt', 'axis',
-                    'border', 'cellpadding', 'cellspacing', 'char',
-                    'charoff', 'charset', 'checked', 'cite',
-                    'clear', 'cols', 'colspan', 'color',
-                    'compact', 'coords', 'datetime', 'details', 'dir',
-                    'disabled', 'enctype', 'for', 'frame',
-                    'headers', 'height', 'hreflang',
-                    'hspace', 'ismap', 'label', 'lang',
-                    'longdesc', 'maxlength', 'media', 'method',
-                    'multiple', 'name', 'nohref', 'noshade',
-                    'nowrap', 'prompt', 'readonly', 'rel', 'rev',
-                    'rows', 'rowspan', 'rules', 'scope',
-                    'selected', 'shape', 'size', 'span',
-                    'start', 'summary', 'tabindex', 'target',
-                    'title', 'type', 'usemap', 'valign', 'value',
-                    'vspace', 'width', 'itemprop']
-        },
-        :protocols => {
-          'a'   => {'href' => ANCHOR_SCHEMES},
-          'img' => {'src'  => ['http', 'https', :relative]}
-        },
-        :transformers => [
-          # Top-level <li> elements are removed because they can break out of
-          # containing markup.
-          lambda { |env|
-            name, node = env[:node_name], env[:node]
-            if name == LIST_ITEM && !node.ancestors.any?{ |n| LISTS.include?(n.name) }
-              node.replace(node.children)
-            end
-          },
+      WHITELIST = Sanitize::Whitelist.new do
+        remove "script"
 
-          # Table child elements that are not contained by a <table> are removed.
-          lambda { |env|
-            name, node = env[:node_name], env[:node]
-            if (TABLE_SECTIONS.include?(name) || TABLE_ITEMS.include?(name)) && !node.ancestors.any? { |n| n.name == TABLE }
-              node.replace(node.children)
-            end
-          }
-        ]
-      }
+        allow %w(
+          h1 h2 h3 h4 h5 h6 h7 h8 br b i strong em a pre code img tt div ins del
+          sup sub p ol ul table thead tbody tfoot blockquote dl dt dd kbd q samp
+          var hr ruby rt rp li tr td th s strike
+        )
+
+        element("a").allow("href").protocols(ANCHOR_SCHEMES)
+        element("img").allow("src").protocols(['http', 'https', :relative])
+        element("div").allow(%w(itemscope itemtype))
+
+        element(:all).allow(
+          %w(abbr accept accept-charset accesskey action align alt axis border
+          cellpadding cellspacing char charoff charset checked cite clear cols
+          colspan color compact coords datetime details dir disabled enctype for
+          frame headers height hreflang hspace ismap label lang longdesc
+          maxlength media method multiple name nohref noshade nowrap prompt
+          readonly rel rev rows rowspan rules scope selected shape size span
+          start summary tabindex target title type usemap valign value vspace
+          width itemprop)
+        )
+
+        # Top-level <li> elements are removed because they can break out of
+        # containing markup.
+        LISTS     = Set.new(%w(ul ol).freeze)
+        LIST_ITEM = 'li'.freeze
+        transform do |env|
+          name, node = env[:node_name], env[:node]
+          if name == LIST_ITEM && !node.ancestors.any?{ |n| LISTS.include?(n.name) }
+            node.replace(node.children)
+          end
+        end
+
+        # Table child elements that are not contained by a <table> are removed.
+        # Otherwise they can be used to break out of containing markup.
+        TABLE_ITEMS = Set.new(%w(tr td th).freeze)
+        TABLE = 'table'.freeze
+        TABLE_SECTIONS = Set.new(%w(thead tbody tfoot).freeze)
+        transform do |env|
+          name, node = env[:node_name], env[:node]
+          if (TABLE_SECTIONS.include?(name) || TABLE_ITEMS.include?(name)) && !node.ancestors.any? { |n| n.name == TABLE }
+            node.replace(node.children)
+          end
+        end
+      end
 
       # A more limited sanitization whitelist. This includes all attributes,
       # protocols, and transformers from WHITELIST but with a more locked down
       # set of allowed elements.
-      LIMITED = WHITELIST.merge(
-        :elements => %w(b i strong em a pre code img ins del sup sub p ol ul li))
+      LIMITED = Sanitize::Whitelist.new do
+        allow %w(b i strong em a pre code img ins del sup sub p ol ul li)
+      end
 
       # Strip all HTML tags from the document.
-      FULL = { :elements => [] }
+      FULL = Sanitize::Whitelist.new
 
       # Sanitize markup using the Sanitize library.
       def call
-        Sanitize.clean_node!(doc, whitelist)
+        Sanitize.clean_node!(doc, whitelist.to_h)
       end
 
       # The whitelist to use when sanitizing. This can be passed in the context
       # hash to the filter but defaults to WHITELIST constant value above.
       def whitelist
         whitelist = context[:whitelist] || WHITELIST
-        anchor_schemes = context[:anchor_schemes]
-        return whitelist unless anchor_schemes
-        whitelist = whitelist.dup
-        whitelist[:protocols] = (whitelist[:protocols] || {}).dup
-        whitelist[:protocols]['a'] = (whitelist[:protocols]['a'] || {}).merge('href' => anchor_schemes)
+
+        if anchor_schemes = context[:anchor_schemes]
+          whitelist = whitelist.dup do
+            element("a").allow("href").protocols(anchor_schemes)
+          end
+        end
+
         whitelist
       end
     end

--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -91,7 +91,7 @@ module HTML
 
       # Sanitize markup using the Sanitize library.
       def call
-        Sanitize.clean_node!(doc, whitelist.to_h)
+        Sanitize.clean_node!(doc, whitelist.to_hash)
       end
 
       # The whitelist to use when sanitizing. This can be passed in the context

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -90,7 +90,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_whitelist_contains_default_anchor_schemes
-    assert_equal SanitizationFilter::WHITELIST.to_h[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::WHITELIST.to_hash[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
   end
 
   def test_whitelist_from_full_constant

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -90,7 +90,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_whitelist_contains_default_anchor_schemes
-    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::WHITELIST.to_h[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
   end
 
   def test_whitelist_from_full_constant


### PR DESCRIPTION
This is an experiment with adding real objects to represent the whitelist instead of a deeply nested hash. See [sanitize-whitelist](https://github.com/bkeepers/sanitize-whitelist) for the implementation.

## Advantages

- `#dup` with a block can be called on existing whitelists to create a new whitelist with modifications
- the whitelist is frozen after it is initialized or dup'd.
- `#to_h` converts it to the hash that the `sanitize` gem expects

## Example

```ruby
class MySanitizationFilter < HTML::Pipeline::SanitizationFilter
  CUSTOM_WHITELIST = WHITELIST.dup do
    remove "object"
    allow "time"
    element(:all).allow("id")
    element("span").allow("class")
  end

  def whitelist
    CUSTOM_WHITELIST
  end
end
```

/cc @jch @mastahyeti @ptoomey3 @mislav @josh