### PR TITLE
Use Linguist lexers

### DIFF
--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -13,7 +13,7 @@ module HTML
         doc.search('pre').each do |node|
           default = context[:highlight] && context[:highlight].to_s
           next unless lang = node['lang'] || default
-          next unless lexer = get_lexer(lang)
+          next unless lexer = lexer_for(lang)
           text = node.inner_text
 
           html = highlight_with_timeout_handling(lexer, text)
@@ -35,12 +35,8 @@ module HTML
         nil
       end
 
-      def get_lexer(lang)
-        lexer = Linguist::Language[lang] && Linguist::Language[lang].lexer
-        unless lexer
-          lexer = Pygments::Lexer[lang]
-        end
-        lexer
+      def lexer_for(lang)
+        (Linguist::Language[lang] && Linguist::Language[lang].lexer) || Pygments::Lexer[lang]
       end
     end
   end


### PR DESCRIPTION
This pull request uses Linguist instead of Pygments to determine which the correct lexer.
This would be more accurate since Linguist sometimes defines languages that Pygments doesn't know (and uses the lexer of another language, see [M](https://github.com/pchaigno/linguist/blob/master/lib/linguist/languages.yml#L1351-L1353)).

If this pull request is merged and the [Linguist gem updated](#152), it would solve the issue at github/linguist#1468.

/cc @bkeepers 
