### PR TITLE
Drop support for gemoji ~> 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 group :test do
   gem "minitest",           "~> 5.3"
   gem "rinku",              "~> 1.7",   :require => false
-  gem "gemoji",             "~> 1.0",   :require => false
+  gem "gemoji",             "~> 2.0",   :require => false
   gem "RedCloth",           "~> 4.2.9", :require => false
   gem "github-markdown",    "~> 0.5",   :require => false
   gem "email_reply_parser", "~> 0.5",   :require => false

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -25,7 +25,7 @@ module HTML
         end
         doc
       end
-      
+
       # Implementation of validate hook.
       # Errors should raise exceptions or use an existing validator.
       def validate
@@ -79,24 +79,12 @@ module HTML
         self.class.emoji_pattern
       end
 
-      # Detect gemoji v2 which has a new API
-      # https://github.com/jch/html-pipeline/pull/129
-      if Emoji.respond_to?(:all)
-        def self.emoji_names
-          Emoji.all.map(&:aliases).flatten.sort
-        end
+      def self.emoji_names
+        Emoji.all.map(&:aliases).flatten.sort
+      end
 
-        def emoji_filename(name)
-          Emoji.find_by_alias(name).image_filename
-        end
-      else
-        def self.emoji_names
-          Emoji.names
-        end
-
-        def emoji_filename(name)
-          "#{::CGI.escape(name)}.png"
-        end
+      def emoji_filename(name)
+        Emoji.find_by_alias(name).image_filename
       end
     end
   end

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -2,22 +2,22 @@ require 'test_helper'
 
 class HTML::Pipeline::EmojiFilterTest < Minitest::Test
   EmojiFilter = HTML::Pipeline::EmojiFilter
-  
+
   def test_emojify
     filter = EmojiFilter.new("<p>:shipit:</p>", {:asset_root => 'https://foo.com'})
     doc = filter.call
     assert_match "https://foo.com/emoji/shipit.png", doc.search('img').attr('src').value
   end
-  
+
   def test_uri_encoding
     filter = EmojiFilter.new("<p>:+1:</p>", {:asset_root => 'https://foo.com'})
     doc = filter.call
-    assert_match "https://foo.com/emoji/%2B1.png", doc.search('img').attr('src').value
+    assert_match "https://foo.com/emoji/unicode/1f44d.png", doc.search('img').attr('src').value
   end
-  
+
   def test_required_context_validation
-    exception = assert_raises(ArgumentError) { 
-      EmojiFilter.call("", {}) 
+    exception = assert_raises(ArgumentError) {
+      EmojiFilter.call("", {})
     }
     assert_match /:asset_root/, exception.message
   end
@@ -25,7 +25,7 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
   def test_custom_asset_path
     filter = EmojiFilter.new("<p>:+1:</p>", {:asset_path => ':file_name', :asset_root => 'https://foo.com'})
     doc = filter.call
-    assert_match "https://foo.com/%2B1.png", doc.search('img').attr('src').value
+    assert_match "https://foo.com/unicode/1f44d.png", doc.search('img').attr('src').value
   end
 
   def test_not_emojify_in_code_tags


### PR DESCRIPTION
Slated for v2.0, this PR drops support for gemoji v1.x.

cc https://github.com/jch/html-pipeline/pull/129 @mislav @josh 