### PR TITLE
Add GitHub flavor Markdown Task List extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Here are some extensions people have built:
 * [html-pipeline-cite](https://github.com/lifted-studios/html-pipeline-cite)
 * [tilt-html-pipeline](https://github.com/bradgessler/tilt-html-pipeline)
 * [html-pipeline-wiki-link'](https://github.com/lifted-studios/html-pipeline-wiki-link) - WikiMedia-style wiki links
+* [task_list](https://github.com/github/task_list) - GitHub flavor Markdown Task List
 
 ## Instrumenting
 


### PR DESCRIPTION
The new [`task_list`](https://github.com/blog/1930-task-lists-are-open-source) gem is [designed to integrate](https://github.com/github/task_list#backend-markdown-pipeline-filter) with `html-pipeline`, so let's add a link in the README!  :smile: 

/cc @mtodd 
