### PR TITLE
Add `about` and `chrome` schemes to ANCHOR_SCHEMES

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -37,7 +37,7 @@ module HTML
       TABLE_SECTIONS = Set.new(%w(thead tbody tfoot).freeze)
 
       # These schemes are the only ones allowed in <a href> attributes by default.
-      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac'].freeze
+      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'about', 'chrome'].freeze
 
       # The main sanitization whitelist. Only these elements and attributes are
       # allowed through by default.

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -65,6 +65,13 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
     assert_equal stuff, html
   end
 
+  def test_custom_anchor_schemes_no_slashes_are_not_removed
+    stuff  = '<a href="about:config">about:config</a>'
+    filter = SanitizationFilter.new(stuff, {:anchor_schemes => ['about']})
+    html = filter.call.to_s
+    assert_equal stuff, html
+  end
+
   def test_anchor_schemes_are_merged_with_other_anchor_restrictions
     stuff  = '<a href="something-weird://heyyy" ping="more-weird://hiii">Wat</a> is this'
     whitelist = {
@@ -90,7 +97,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_whitelist_contains_default_anchor_schemes
-    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'about', 'chrome']
   end
 
   def test_whitelist_from_full_constant
@@ -101,7 +108,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_exports_default_anchor_schemes
-    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'about', 'chrome']
   end
 
   def test_script_contents_are_removed


### PR DESCRIPTION
Add extra schemes to allow maintaining href attributes containing values such as
`about:config`, `about:blank`, `chrome://accessibility`.
