### PR TITLE
Use the new build env on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
+
+sudo: false


### PR DESCRIPTION
More RAM, dedicated cpu cores, awesome network performance, fantastic VM boot times.

> Using our new container-based stack only requires one additional line in your .travis.yml:
> `sudo: false`

Source: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

:smile: 
