### PR TITLE
Implement new context option: ignored_ancestor_tags to accept more ignored tags.

### DIFF
--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -13,19 +13,23 @@ module HTML
     # Context:
     #   :asset_root (required) - base url to link to emoji sprite
     #   :asset_path (optional) - url path to link to emoji sprite. :file_name can be used as a placeholder for the sprite file name. If no asset_path is set "emoji/:file_name" is used.
+    #   :ignored_ancestor_tags (optional) - Tags to stop the emojification. Node has matched ancestor HTML tags will not be emojified. Default to pre, code, and tt tags. Extra tags please pass in the form of array, e.g., %w(blockquote summary).
     class EmojiFilter < Filter
+
+      DEFAULT_IGNORED_ANCESTOR_TAGS = %w(pre code tt).freeze
+
       def call
         doc.search('text()').each do |node|
           content = node.to_html
           next unless content.include?(':')
-          next if has_ancestor?(node, %w(pre code tt))
+          next if has_ancestor?(node, ignored_ancestor_tags)
           html = emoji_image_filter(content)
           next if html == content
           node.replace(html)
         end
         doc
       end
-      
+
       # Implementation of validate hook.
       # Errors should raise exceptions or use an existing validator.
       def validate
@@ -96,6 +100,17 @@ module HTML
 
         def emoji_filename(name)
           "#{::CGI.escape(name)}.png"
+        end
+      end
+
+      # Return ancestor tags to stop the emojification.
+      #
+      # @return [Array<String>] Ancestor tags.
+      def ignored_ancestor_tags
+        if context[:ignored_ancestor_tags]
+          DEFAULT_IGNORED_ANCESTOR_TAGS | context[:ignored_ancestor_tags]
+        else
+          DEFAULT_IGNORED_ANCESTOR_TAGS
         end
       end
     end

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -2,22 +2,22 @@ require 'test_helper'
 
 class HTML::Pipeline::EmojiFilterTest < Minitest::Test
   EmojiFilter = HTML::Pipeline::EmojiFilter
-  
+
   def test_emojify
     filter = EmojiFilter.new("<p>:shipit:</p>", {:asset_root => 'https://foo.com'})
     doc = filter.call
     assert_match "https://foo.com/emoji/shipit.png", doc.search('img').attr('src').value
   end
-  
+
   def test_uri_encoding
     filter = EmojiFilter.new("<p>:+1:</p>", {:asset_root => 'https://foo.com'})
     doc = filter.call
     assert_match "https://foo.com/emoji/%2B1.png", doc.search('img').attr('src').value
   end
-  
+
   def test_required_context_validation
-    exception = assert_raises(ArgumentError) { 
-      EmojiFilter.call("", {}) 
+    exception = assert_raises(ArgumentError) {
+      EmojiFilter.call("", {})
     }
     assert_match /:asset_root/, exception.message
   end
@@ -45,6 +45,20 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
   def test_not_emojify_in_pre_tags
     body = "<pre>:shipit:</pre>"
     filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com'})
+    doc = filter.call
+    assert_equal body, doc.to_html
+  end
+
+  def test_not_emojify_in_custom_single_tag_foo
+    body = "<foo>:shipit:</foo>"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com', ignored_ancestor_tags: %w(foo)})
+    doc = filter.call
+    assert_equal body, doc.to_html
+  end
+
+  def test_not_emojify_in_custom_multiple_tags_foo_and_bar
+    body = "<bar>:shipit:</bar>"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com', ignored_ancestor_tags: %w(foo bar)})
     doc = filter.call
     assert_equal body, doc.to_html
   end


### PR DESCRIPTION
Hello maintainer,

~~I attempt to fix #163 by implemented `ignored_pattern`.~~

> This filter is designed to run on HTML fragments, so we should assume that tags is a reasonable input to work with.

And while reading conversations in #163,

> The EmojiFilter has something similar, but it doesn't use a constant.
> — @simeonwillbanks

above quote inspired me to implement ignored_ancestor_tags.

Then we could specify more tags to stop the emojification process if we want.

Please take a look. :bow: :pray: 

Thanks!!