### PR TITLE
Whitelist summary and details element.

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -45,7 +45,7 @@ module HTML
         :elements => %w(
           h1 h2 h3 h4 h5 h6 h7 h8 br b i strong em a pre code img tt
           div ins del sup sub p ol ul table thead tbody tfoot blockquote
-          dl dt dd kbd q samp var hr ruby rt rp li tr td th s strike
+          dl dt dd kbd q samp var hr ruby rt rp li tr td th s strike summary details
         ),
         :remove_contents => ['script'],
         :attributes => {
@@ -57,13 +57,13 @@ module HTML
                     'border', 'cellpadding', 'cellspacing', 'char',
                     'charoff', 'charset', 'checked', 'cite',
                     'clear', 'cols', 'colspan', 'color',
-                    'compact', 'coords', 'datetime', 'details', 'dir',
+                    'compact', 'coords', 'datetime', 'dir',
                     'disabled', 'enctype', 'for', 'frame',
                     'headers', 'height', 'hreflang',
                     'hspace', 'ismap', 'label', 'lang',
                     'longdesc', 'maxlength', 'media', 'method',
                     'multiple', 'name', 'nohref', 'noshade',
-                    'nowrap', 'prompt', 'readonly', 'rel', 'rev',
+                    'nowrap', 'open', 'prompt', 'readonly', 'rel', 'rev',
                     'rows', 'rowspan', 'rules', 'scope',
                     'selected', 'shape', 'size', 'span',
                     'start', 'summary', 'tabindex', 'target',

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -127,4 +127,28 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
 </table>)
     assert_equal orig, SanitizationFilter.call(orig).to_s
   end
+
+  def test_summary_tag_are_not_removed
+    orig = %(<summary>Foo</summary>)
+    assert_equal orig, SanitizationFilter.call(orig).to_s
+  end
+
+  def test_details_tag_and_open_attribute_are_not_removed
+    orig = %(<details open>Foo</details>)
+    assert_equal orig, SanitizationFilter.call(orig).to_s
+  end
+
+  def test_nested_details_tag_are_not_removed
+    orig = <<-NESTED
+      <details>
+        <summary>Foo</summary>
+        <details>
+          Bar
+          <summary>Baz</summary>
+        </details>
+        Qux
+      </details>
+    NESTED
+    assert_equal orig, SanitizationFilter.call(orig).to_s
+  end
 end


### PR DESCRIPTION
Hello there,

This Pull Request is a follow-up to #138. I added summary and details to elements whitelist and add few tests. And `details` element needs an `open` attribute according to [MDN HTML attribute reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes).

Please take a look. :mag_right: :mag_right: :mag_right: 

Thanks!