### PR TITLE
MentionFilter#link_to_mentioned_user: Replace String introspection with Regexp match

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -126,7 +126,7 @@ module HTML
       def link_to_mentioned_user(login)
         result[:mentioned_usernames] |= [login]
 
-        base_url << "/" unless base_url.last =~ /\/|~/
+        base_url << "/" unless base_url =~ /[\/~]\z/
 
         "<a href='#{base_url << login}' class='user-mention'>" +
         "@#{login}" +


### PR DESCRIPTION
#167 introduced a subtle bug by relying upon `ActiveSupport`'s `String#last`.  The tests passed because the test helper [requires `active_support/core_ext/string`](https://github.com/jch/html-pipeline/blob/master/test/test_helper.rb#L5).  

Not all applications will require `ActiveSupport`'s `String`, and the extension seemed heavy for the `MentionFilter`.  

This Pull Request improves the existing `Regexp`, so the `MentionFilter` doesn't need `ActiveSupport`'s `String`.

**Commit Message:**
- `last` requires ActiveSupport and applications may not have required
   'active_support/core_ext/string'
- Instead of extracting the last character and matching against that
  character, refactor the Regexp, so it tests the last character of
  the `base_url`