### PR TITLE
Add 3rd party gem: html-pipeline-rouge_filter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Here are some extensions people have built:
 * [tilt-html-pipeline](https://github.com/bradgessler/tilt-html-pipeline)
 * [html-pipeline-wiki-link'](https://github.com/lifted-studios/html-pipeline-wiki-link) - WikiMedia-style wiki links
 * [task_list](https://github.com/github/task_list) - GitHub flavor Markdown Task List
+* [html-pipeline-rouge_filter](https://github.com/JuanitoFatas/html-pipeline-rouge_filter) - Syntax highlight with [Rouge](https://github.com/jneen/rouge/)
 
 ## Instrumenting
 


### PR DESCRIPTION
This gem is smiliar to `SyntaxHighlightFilter` but use [rouge](https://github.com/jneen/rouge/) instead of [pygments.rb](https://github.com/tmm1/pygments.rb): [html-pipeline-rouge_filter](https://github.com/JuanitoFatas/html-pipeline-rouge_filter).

Implement #166. :blush: 