### PR TITLE
Restrict nokogiri to specific versions

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^test})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "nokogiri", "~> 1.4"
+  gem.add_dependency "nokogiri", [">= 1.4", "<= 1.6.5"]
   gem.add_dependency "activesupport", ">= 2"
 
   gem.post_install_message = <<msg


### PR DESCRIPTION
- Fixes [Travis CI Build #425 Failure](https://travis-ci.org/jch/html-pipeline/builds/50084589)
  - [nokogiri 1.6.6.2 bundled](https://travis-ci.org/jch/html-pipeline/jobs/50084590#L115)
- As identified in https://github.com/jch/html-pipeline/pull/170#issuecomment-71345882,
  nokogiri 1.6.x is buggy
  - Team nokogiri is working on the fix
    https://github.com/sparklemotion/nokogiri/issues/1233
- Until the bug is fixed, define a range of working nokogiri gems