### PR TITLE
[ci skip] Fix CHANGELOG.md rendering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.11.0
 
   * Search for text nodes on DocumentFragments without root tags #146 Razer6
-  * Don't filter @mentions in <style> tags #145 jch
+  * Don't filter @mentions in `<style>` tags #145 jch
   * Prefer `http_url` in HttpsFilter. `base_url` still works. #142 bkeepers
   * Remove duplicate check in EmojiFilter #141 Razer6
 


### PR DESCRIPTION
This `<style>` tag mess up rendering of [CHANGELOG.md](https://github.com/jch/html-pipeline/blob/master/CHANGELOG.md).

**Before this pull request:**

[CHANGELOG.md (master)](https://github.com/jch/html-pipeline/blob/master/CHANGELOG.md)

**After this pull request:**

[CHANGELOG.md](https://github.com/JuanitoFatas/html-pipeline/blob/fix/changelog/CHANGELOG.md)

@jch Do you generate changelog by this [script](https://github.com/jch/release-scripts)? May need to update.