### PR TITLE
Add XMPP scheme

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -37,7 +37,7 @@ module HTML
       TABLE_SECTIONS = Set.new(%w(thead tbody tfoot).freeze)
 
       # These schemes are the only ones allowed in <a href> attributes by default.
-      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac'].freeze
+      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'xmpp'].freeze
 
       # The main sanitization whitelist. Only these elements and attributes are
       # allowed through by default.


### PR DESCRIPTION
Adding XMPP scheme xmpp: support as recommended on https://github.com/github/markup/issues/426

Specification
http://tools.ietf.org/html/rfc5122

According to http://tools.ietf.org/html/rfc5122#section-2.3

xmpp:// and xmpp: are quite different though, wondering how this will behave