### PR TITLE
Constrain active support >= 2, < 5

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "nokogiri", [">= 1.4", "<= 1.6.5"]
-  gem.add_dependency "activesupport", ">= 2"
+  gem.add_dependency "activesupport", [">= 2", "< 5"]
 
   gem.post_install_message = <<msg
 -------------------------------------------------


### PR DESCRIPTION
ActiveSupport isn't updated frequently, but the previous open ended `>= 2` could lead to breaking changes. This PR constrains it.