### PR TITLE
[MentionFilter] Dup string before modifying

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -126,9 +126,10 @@ module HTML
       def link_to_mentioned_user(login)
         result[:mentioned_usernames] |= [login]
 
-        base_url << "/" unless base_url =~ /[\/~]\z/
+        url = base_url.dup
+        url << "/" unless url =~ /[\/~]\z/
 
-        "<a href='#{base_url << login}' class='user-mention'>" +
+        "<a href='#{url << login}' class='user-mention'>" +
         "@#{login}" +
         "</a>"
       end


### PR DESCRIPTION
Follow up to #167. This PR dupes the string before modifying it. It's a subtle difference, but the previous behavior created a new string before modifying it. This preserves that behavior to avoid surprises.

cc @JuanitoFatas 