### PR TITLE
Added rewrite anchor target filter

### DIFF
--- a/lib/html/pipeline.rb
+++ b/lib/html/pipeline.rb
@@ -41,6 +41,7 @@ module HTML
     autoload :TextileFilter,         'html/pipeline/textile_filter'
     autoload :TableOfContentsFilter, 'html/pipeline/toc_filter'
     autoload :TextFilter,            'html/pipeline/text_filter'
+    autoload :AnchorTargetFilter,    'html/pipeline/anchor_target_filter'
 
     # Our DOM implementation.
     DocumentFragment = Nokogiri::HTML::DocumentFragment

--- a/lib/html/pipeline/anchor_target_filter.rb
+++ b/lib/html/pipeline/anchor_target_filter.rb
@@ -1,0 +1,38 @@
+module HTML
+  class Pipeline
+    # HTML filter that rewrites 'target' attribute to all anchors in a document.
+    # Useful for causing to open in a new tab (set target to '_blank').
+    #
+    # Context options:
+    #   :target - The target to be added to <a>, defaults to TARGET ('_default')
+    #             Set to 'false' to remove targets
+    #
+    class AnchorTargetFilter < Filter
+      TARGET = '_default'
+
+      def call
+        doc.css('a').each do |element|
+          if target == false
+            element.attributes['target'].remove
+          else
+            element.set_attribute('target', target)
+          end
+        end
+        doc
+      end
+
+      # if target is nil, replace with default TARGET
+      # if target is false, remove target
+      def target
+        case context[:target]
+        when false
+          false
+        when nil
+          TARGET
+        else
+          context[:target]
+        end
+      end
+    end
+  end
+end

--- a/test/html/pipeline/anchor_target_filter_test.rb
+++ b/test/html/pipeline/anchor_target_filter_test.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+require 'test_helper'
+
+class HTML::Pipeline::AnchorTargetFilterTest < Minitest::Test
+  AnchorTargetFilter = HTML::Pipeline::AnchorTargetFilter
+
+  def filter(body, options={})
+    AnchorTargetFilter.to_html(body, options)
+  end
+
+  def test_anchors_are_added_properly
+    assert_equal %(<a href="https://www.github.com" target="_default">GitHub</a>),
+          filter(%(<a href="https://www.github.com">GitHub</a>))
+  end
+
+  def test_uses_context_target_over_default_target
+    assert_equal %(<a href="https://www.github.com" target="test">GitHub</a>),
+          filter(%(<a href="https://www.github.com">GitHub</a>),
+                 target: 'test')
+  end
+
+  def test_only_changes_anchor_tags
+    assert_equal %(<blink>test!</blink>),
+          filter(%(<blink>test!</blink>))
+  end
+
+  def test_replaces_existing_target
+    assert_equal %(<a href="https://www.github.com" target="_default">GitHub</a>),
+          filter(%(<a href="https://www.github.com" target="test">GitHub</a>))
+  end
+
+  def test_context_target_false_removes_targets
+    assert_equal %(<a href="https://www.github.com">GitHub</a>),
+          filter(%(<a href="https://www.github.com" target="test">GitHub</a>),
+                 target: false)
+  end
+end


### PR DESCRIPTION
Is it cool if I submit a new filter?

Added `AnchorTargetFilter`:

```
# HTML filter that rewrites 'target' attribute to all anchors in a document.
# Useful for causing to open in a new tab (set target to '_blank').
#
# Context options:
#   :target - The target to be added to <a>, defaults to TARGET ('_default')
#                Set to 'false' to remove targets from anchors.
#
```

