### PR TITLE
Render irc and ircs URLs

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -37,7 +37,7 @@ module HTML
       TABLE_SECTIONS = Set.new(%w(thead tbody tfoot).freeze)
 
       # These schemes are the only ones allowed in <a href> attributes by default.
-      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac'].freeze
+      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'irc', 'ircs'].freeze
 
       # The main sanitization whitelist. Only these elements and attributes are
       # allowed through by default.

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -90,7 +90,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_whitelist_contains_default_anchor_schemes
-    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'irc', 'ircs']
   end
 
   def test_whitelist_from_full_constant
@@ -101,7 +101,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_exports_default_anchor_schemes
-    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac', 'irc', 'ircs']
   end
 
   def test_script_contents_are_removed


### PR DESCRIPTION
An instance of what this would look like can be seen in the [README.rst for python-gssapi](https://github.com/pythongssapi/python-gssapi#get-involved) in the "Get Involved" section: the channel listing should be a link, as can be seen in [the source](https://github.com/pythongssapi/python-gssapi/blob/master/README.txt#L155-156).

[Markup](https://github.com/github/markup) already handles this correctly; I have also tested with [pandoc](https://github.com/jgm/pandoc), which rendered it correctly as well.  The problem seems to be that `irc://` is not an acceptable URL prefix.

The convention of using `irc://` URLs is not new; [Mozilla](http://www-archive.mozilla.org/projects/rt-messaging/chatzilla/irc-urls.html), [mIRC](http://www.mirc.com/mirclink.html), and others have been using this for some time.
