### PR TITLE
Add dependencies into gemspec

### DIFF
--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "nokogiri", [">= 1.4", "<= 1.6.5"]
   gem.add_dependency "activesupport", [">= 2", "< 5"]
+  gem.add_dependency "rinku", "~> 1.7"
 
   gem.post_install_message = <<msg
 -------------------------------------------------


### PR DESCRIPTION
I think it would be nicer if we add the dependencies into gemspec and specify their version, this can prevent some dependency issue.
For example, the `rinku` gem's version I am using is `1.5`, and the `AutolinkFilter` uses version `1.7`'s method, so I got wrong argument error during runtime. If we specify dependency's version, we can know that the dependencies is conflict during bundle, and it's more straightforward for debugging.