### PR TITLE
Update autolink_filter's implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 group :test do
   gem "minitest",           "~> 5.3"
-  gem "rinku",              "~> 1.7",   :require => false
+  gem "rinku",              "~> 1.7.2", :require => false
   gem "gemoji",             "~> 2.0",   :require => false
   gem "RedCloth",           "~> 4.2.9", :require => false
   gem "github-markdown",    "~> 0.5",   :require => false

--- a/lib/html/pipeline/autolink_filter.rb
+++ b/lib/html/pipeline/autolink_filter.rb
@@ -21,10 +21,7 @@ module HTML
         return html if context[:autolink] == false
 
         skip_tags = context[:skip_tags]
-        flags = 0
-        flags |= context[:flags] if context[:flags]
-
-        Rinku.auto_link(html, :urls, context[:link_attr], skip_tags, flags)
+        Rinku.auto_link(html, :urls, context[:link_attr], skip_tags)
       end
     end
   end

--- a/test/html/pipeline/autolink_filter_test.rb
+++ b/test/html/pipeline/autolink_filter_test.rb
@@ -20,11 +20,6 @@ class HTML::Pipeline::AutolinkFilterTest < Minitest::Test
       AutolinkFilter.to_html('<p>"http://www.github.com"</p>', :link_attr => 'target="_blank"')
   end
 
-  def test_autolink_flags
-    assert_equal '<p>"<a href="http://github">http://github</a>"</p>',
-      AutolinkFilter.to_html('<p>"http://github"</p>', :flags => Rinku::AUTOLINK_SHORT_DOMAINS)
-  end
-
   def test_autolink_skip_tags
     assert_equal '<code>"http://github.com"</code>',
       AutolinkFilter.to_html('<code>"http://github.com"</code>')


### PR DESCRIPTION
I updated the `rinku` gem from `1.7` to `1.7.2`. And `Rinku#auto_link` in `1.7.2` takes only four arguments, so I also updated AutolinkFilter#call and it's test.