### PR TITLE
Add ImageFilter for image url to img tag conversion

### DIFF
--- a/lib/html/pipeline.rb
+++ b/lib/html/pipeline.rb
@@ -32,6 +32,7 @@ module HTML
     autoload :EmailReplyFilter,      'html/pipeline/email_reply_filter'
     autoload :EmojiFilter,           'html/pipeline/emoji_filter'
     autoload :HttpsFilter,           'html/pipeline/https_filter'
+    autoload :ImageFilter,           'html/pipeline/image_filter'
     autoload :ImageMaxWidthFilter,   'html/pipeline/image_max_width_filter'
     autoload :MarkdownFilter,        'html/pipeline/markdown_filter'
     autoload :MentionFilter,         'html/pipeline/@mention_filter'

--- a/lib/html/pipeline/image_filter.rb
+++ b/lib/html/pipeline/image_filter.rb
@@ -2,7 +2,7 @@ module HTML
   class Pipeline
     class ImageFilter < TextFilter
       def call
-        @text.gsub(/https?:\/\/.+\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
+        @text.gsub(/(https|http)?:\/\/.+\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
         %|<img src="#{match}" alt=""/>|
         end
       end

--- a/lib/html/pipeline/image_filter.rb
+++ b/lib/html/pipeline/image_filter.rb
@@ -1,5 +1,11 @@
 module HTML
   class Pipeline
+    # HTML Filter that converts image's url into <img> tag.
+    # For example, it will convert
+    #   http://example.com/test.jpg
+    # into
+    #   <img src="http://example.com/test.jpg" alt=""/>.
+
     class ImageFilter < TextFilter
       def call
         @text.gsub(/(https|http)?:\/\/.+\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|

--- a/lib/html/pipeline/image_filter.rb
+++ b/lib/html/pipeline/image_filter.rb
@@ -1,0 +1,11 @@
+module HTML
+  class Pipeline
+    class ImageFilter < TextFilter
+      def call
+        @text.gsub(/https?:\/\/.+\.(jpg|jpeg|bmp|gif|png)(\?\S+)?/i) do |match|
+        %|<img src="#{match}" alt=""/>|
+        end
+      end
+    end
+  end
+end

--- a/test/html/pipeline/image_filter_test.rb
+++ b/test/html/pipeline/image_filter_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+ImageFilter = HTML::Pipeline::ImageFilter
+
+class HTML::Pipeline::ImageFilterTest < Minitest::Test
+  def filter(html)
+    ImageFilter.to_html(html)
+  end
+
+  def test_jpg
+    assert_equal %(<img src="http://example.com/test.jpg" alt=""/>),
+    filter(%(http://example.com/test.jpg))
+  end
+
+  def test_jpeg
+    assert_equal %(<img src="http://example.com/test.jpeg" alt=""/>),
+    filter(%(http://example.com/test.jpeg))
+  end
+
+  def test_bmp
+    assert_equal %(<img src="http://example.com/test.bmp" alt=""/>),
+    filter(%(http://example.com/test.bmp))
+  end
+
+  def test_gif
+    assert_equal %(<img src="http://example.com/test.gif" alt=""/>),
+    filter(%(http://example.com/test.gif))
+  end
+
+  def test_png
+    assert_equal %(<img src="http://example.com/test.png" alt=""/>),
+    filter(%(http://example.com/test.png))
+  end
+
+  def test_https_url
+    assert_equal %(<img src="https://example.com/test.png" alt=""/>),
+    filter(%(https://example.com/test.png))
+  end
+end


### PR DESCRIPTION
This simple filter converts url like: `https://example.com/test.png` into image tag like
```html
<img src="https://example.com/test.png" alt=""/>
```