### PR TITLE
Soften Nokogiri dependency to versions ">= 1.4"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2.1
+
+* Soften Nokogiri dependency to versions ">= 1.4" [#208](https://github.com/jch/html-pipeline/pull/208)
+
 ## 2.2.0
 
 * Only allow cite attribute on blockquote and restrict schemes [#223](https://github.com/jch/html-pipeline/pull/223)

--- a/html-pipeline.gemspec
+++ b/html-pipeline.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^test})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "nokogiri", [">= 1.4", "<= 1.6.5"]
+  gem.add_dependency "nokogiri", ">= 1.4"
   gem.add_dependency "activesupport", [">= 2", "< 5"]
 
   gem.post_install_message = <<msg

--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -70,7 +70,7 @@ module HTML
       def call
         result[:mentioned_usernames] ||= []
 
-        doc.search('text()').each do |node|
+        doc.search('.//text()').each do |node|
           content = node.to_html
           next if !content.include?('@')
           next if has_ancestor?(node, IGNORE_PARENTS)

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -19,7 +19,7 @@ module HTML
       DEFAULT_IGNORED_ANCESTOR_TAGS = %w(pre code tt).freeze
 
       def call
-        doc.search('text()').each do |node|
+        doc.search('.//text()').each do |node|
           content = node.to_html
           next unless content.include?(':')
           next if has_ancestor?(node, ignored_ancestor_tags)

--- a/lib/html/pipeline/version.rb
+++ b/lib/html/pipeline/version.rb
@@ -1,5 +1,5 @@
 module HTML
   class Pipeline
-    VERSION = "2.2.0"
+    VERSION = "2.2.1"
   end
 end


### PR DESCRIPTION
Many Ruby / Rails projects already use Nokogiri 1.6.6.x series.
`<= 1.6.5` constraint make these projects impossible to integrate html-pipeline.
This pull request uses the workaround mentioned in https://github.com/sparklemotion/nokogiri/issues/1233#issuecomment-71462081.

If this change is okay, then will need:

- [x] an CHANGELOG entry + Release 2.2.1
- [x] ~~Backport this change to 1.11.0, Release 1.11.1 + an CHANGELOG entry~~ Found out no need to do this because at v1.10.0, the Nokogiri dependency is locked at [~> 1.4](https://github.com/jch/html-pipeline/blob/v1.11.0/html-pipeline.gemspec#L18).

--

Related: #176 