### PR TITLE
Whitelist schemes for longdesc

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -72,7 +72,10 @@ module HTML
         },
         :protocols => {
           'a'   => {'href' => ANCHOR_SCHEMES},
-          'img' => {'src'  => ['http', 'https', :relative]}
+          'img' => {
+            'src'      => ['http', 'https', :relative],
+            'longdesc' => ['http', 'https', :relative]
+          }
         },
         :transformers => [
           # Top-level <li> elements are removed because they can break out of

--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -50,7 +50,7 @@ module HTML
         :remove_contents => ['script'],
         :attributes => {
           'a' => ['href'],
-          'img' => ['src'],
+          'img' => ['src', 'longdesc'],
           'div' => ['itemscope', 'itemtype'],
           :all  => ['abbr', 'accept', 'accept-charset',
                     'accesskey', 'action', 'align', 'alt', 'axis',
@@ -61,7 +61,7 @@ module HTML
                     'disabled', 'enctype', 'for', 'frame',
                     'headers', 'height', 'hreflang',
                     'hspace', 'ismap', 'label', 'lang',
-                    'longdesc', 'maxlength', 'media', 'method',
+                    'maxlength', 'media', 'method',
                     'multiple', 'name', 'nohref', 'noshade',
                     'nowrap', 'open', 'prompt', 'readonly', 'rel', 'rev',
                     'rows', 'rowspan', 'rules', 'scope',

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -51,6 +51,18 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
     assert_equal '<a>Wat</a> is this', html
   end
 
+  def test_whitelisted_longdesc_schemes_are_allowed
+    stuff = '<img src="./foo.jpg" longdesc="http://longdesc.com">'
+    html  = SanitizationFilter.call(stuff).to_s
+    assert_equal '<img src="./foo.jpg" longdesc="http://longdesc.com">', html
+  end
+
+  def test_weird_longdesc_schemes_are_removed
+    stuff = '<img src="./foo.jpg" longdesc="javascript:alert(1)">'
+    html  = SanitizationFilter.call(stuff).to_s
+    assert_equal '<img src="./foo.jpg">', html
+  end
+
   def test_standard_schemes_are_removed_if_not_specified_in_anchor_schemes
     stuff  = '<a href="http://www.example.com/">No href for you</a>'
     filter = SanitizationFilter.new(stuff, {:anchor_schemes => []})


### PR DESCRIPTION
This limits the URL schemes that can be used for image tags' `longdesc` attribute.

/cc @jch @gregose @ptoomey3 @oreoshake