### PR TITLE
Fix for calling mention_link_filter with only one argument

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -103,7 +103,7 @@ module HTML
       #
       # Returns a string with @mentions replaced with links. All links have a
       # 'user-mention' class name attached for styling.
-      def mention_link_filter(text, base_url='/', info_url=nil, username_pattern)
+      def mention_link_filter(text, base_url='/', info_url=nil, username_pattern=UsernamePattern)
         self.class.mentioned_logins_in(text, username_pattern) do |match, login, is_mentioned|
           link =
             if is_mentioned

--- a/test/html/pipeline/mention_filter_test.rb
+++ b/test/html/pipeline/mention_filter_test.rb
@@ -203,4 +203,10 @@ class HTML::Pipeline::MentionFilterTest < Minitest::Test
     filter(doc.clone, '/', nil, /test/)
     assert_equal pattern_count + 1, HTML::Pipeline::MentionFilter::MentionPatterns.length
   end
+
+  def test_mention_link_filter
+    filter = HTML::Pipeline::MentionFilter.new nil
+    expected = "<a href='/hubot' class='user-mention'>@hubot</a>"
+    assert_equal expected, filter.mention_link_filter("@hubot")
+  end
 end


### PR DESCRIPTION
Currently, the 4th argument for `HTML::Pipeline::MentionFilter#mention_link_filter`, `username_pattern`, is required, even though args 2 and 3 are optional.  

I believe this is a regression introduced in https://github.com/jch/html-pipeline/pull/157.

I copied the default argument format of `mentioned_logins_in` to default the final argument to `UsernamePattern` and added a test (the `mention_link_filter` had no tests previously AFAIK).

### Before:

```irb
> filter = HTML::Pipeline::MentionFilter.new nil
=> #<HTML::Pipeline::MentionFilter:0x007fc70aa759d0 @doc=nil, @html=nil, @context={}, @result={}>
> filter.mention_link_filter "@hubot"
ArgumentError: wrong number of arguments (1 for 2..4)
	from /usr/local/opt/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/html-pipeline-2.2.1/lib/html/pipeline/@mention_filter.rb:106:in `mention_link_filter'
```

### After

```irb
> filter = HTML::Pipeline::MentionFilter.new nil
=> #<HTML::Pipeline::MentionFilter:0x007fc76b019688 @doc=nil, @html=nil, @context={}, @result={}>
> filter.mention_link_filter "@hubot"
=> "<a href='/hubot' class='user-mention'>@hubot</a>"
```

/cc @brittballard 