### PR TITLE
explicitly depend upon pygments.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ group :test do
   else
     gem "escape_utils",     "~> 1.0",   :require => false
     gem "github-linguist",  "~> 2.10",  :require => false
+    # github-linguist version > 4 need to explicitly include pygments.rb,
+    # see https://github.com/jch/html-pipeline/issues/235
+    # gem "pygments.rb",                :require => false
   end
 
   if RUBY_VERSION < "1.9.3"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ add the following to your Gemfile:
 
 ```ruby
 gem 'github-linguist'
+gem 'pygments.rb'
 ```
 
 * `AutolinkFilter` - `rinku`

--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -4,6 +4,12 @@ rescue LoadError => _
   abort "Missing dependency 'github-linguist' for SyntaxHighlightFilter. See README.md for details."
 end
 
+begin
+  require "pygments"
+rescue LoadError => _
+  abort "Missing dependency 'pygments.rb' for SyntaxHighlightFilter. See README.md for details."
+end
+
 module HTML
   class Pipeline
     # HTML Filter that syntax highlights code blocks wrapped

--- a/test/html/pipeline/syntax_highlight_filter_test.rb
+++ b/test/html/pipeline/syntax_highlight_filter_test.rb
@@ -19,4 +19,12 @@ class HTML::Pipeline::SyntaxHighlightFilterTest < Minitest::Test
     assert doc.css(".highlight-coffeescript").empty?
     assert !doc.css(".highlight-c").empty?
   end
+
+  def test_highlight_unknown
+    filter = SyntaxHighlightFilter.new \
+      "<pre>hello</pre>", :highlight => "something"
+
+    doc = filter.call
+    assert doc.css(".highlight-something").empty?
+  end
 end


### PR DESCRIPTION
fixes #235 

To reproduce, change the Gemfile from:

``` ruby
    gem "github-linguist",  "~> 2.10",  :require => false
```

to

``` ruby
    gem "github-linguist",  "> 2.10",  :require => false
```

and `bundle update`

I tried not requiring 'pygments.rb', and using `defined?`, but it looked like nothing worked without including the requirement.

I updated the `README` as well.
