### PR TITLE
Use entire namespace so exception constant is resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2.4
+
+* Use entire namespace so MissingDependencyError constant is resolved [#243](https://github.com/jch/html-pipeline/pull/243)
+
 ## 2.2.3
 
 * raise MissingDependencyError instead of aborting on missing dependency [#241](https://github.com/jch/html-pipeline/pull/241)

--- a/lib/html/pipeline/autolink_filter.rb
+++ b/lib/html/pipeline/autolink_filter.rb
@@ -1,7 +1,7 @@
 begin
   require "rinku"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'rinku' for AutolinkFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'rinku' for AutolinkFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -1,13 +1,13 @@
 begin
   require "escape_utils"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'escape_utils' for EmailReplyFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'escape_utils' for EmailReplyFilter. See README.md for details."
 end
 
 begin
   require "email_reply_parser"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'email_reply_parser' for EmailReplyFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'email_reply_parser' for EmailReplyFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -3,7 +3,7 @@ require "cgi"
 begin
   require "gemoji"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'gemoji' for EmojiFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'gemoji' for EmojiFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -1,7 +1,7 @@
 begin
   require "github/markdown"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'github-markdown' for MarkdownFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'github-markdown' for MarkdownFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/plain_text_input_filter.rb
+++ b/lib/html/pipeline/plain_text_input_filter.rb
@@ -1,7 +1,7 @@
 begin
   require "escape_utils"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'escape_utils' for PlainTextInputFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'escape_utils' for PlainTextInputFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -1,7 +1,7 @@
 begin
   require "sanitize"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'sanitize' for SanitizationFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'sanitize' for SanitizationFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -1,7 +1,7 @@
 begin
   require "linguist"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'github-linguist' for SyntaxHighlightFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'github-linguist' for SyntaxHighlightFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/textile_filter.rb
+++ b/lib/html/pipeline/textile_filter.rb
@@ -1,7 +1,7 @@
 begin
   require "redcloth"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'RedCloth' for TextileFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'RedCloth' for TextileFilter. See README.md for details."
 end
 
 module HTML

--- a/lib/html/pipeline/version.rb
+++ b/lib/html/pipeline/version.rb
@@ -1,5 +1,5 @@
 module HTML
   class Pipeline
-    VERSION = "2.2.3"
+    VERSION = "2.2.4"
   end
 end


### PR DESCRIPTION
### Problem

#241 introduced a custom exception, but it used the exception outside the `HTML::Pipeline` namespace.


```
~/Code/html-pipeline master
❯ irb -I lib
[1] pry(main)> require 'html/pipeline'
=> true
[2] pry(main)> filter = HTML::Pipeline::MarkdownFilter.new("Hi **world**!")
NameError: uninitialized constant MissingDependencyError
from /Users/simeonwillbanks/Code/html-pipeline/lib/html/pipeline/markdown_filter.rb:4:in `rescue in <top (required)>'
[3] pry(main)> require "github/markdown"
LoadError: cannot load such file -- github/markdown
from /usr/local/var/rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```

### Solution

Resolve the exception constant by using the full namespace.

```
~/Code/html-pipeline add-namespace-to-missing-deps-raise
❯ git diff
diff --git a/lib/html/pipeline/markdown_filter.rb b/lib/html/pipeline/markdown_filter.rb
index 94a820a..b16dfc8 100644
--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -1,7 +1,7 @@
 begin
   require "github/markdown"
 rescue LoadError => _
-  raise MissingDependencyError, "Missing dependency 'github-markdown' for MarkdownFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'github-markdown' for MarkdownFilter. See README.md for detai
 end

 module HTML

~/Code/html-pipeline add-namespace-to-missing-deps-raise*
❯ irb -I lib
[1] pry(main)> require 'html/pipeline'
=> true
[2] pry(main)> filter = HTML::Pipeline::MarkdownFilter.new("Hi **world**!")
HTML::Pipeline::MissingDependencyError: Missing dependency 'github-markdown' for MarkdownFilter. See README.md for details.
from /Users/simeonwillbanks/Code/html-pipeline/lib/html/pipeline/markdown_filter.rb:4:in `rescue in <top (required)>'
```

/cc @parkr @jch