### PR TITLE
Creating the option to pass in an anchor icon, instead of using octicons

### DIFF
--- a/lib/html/pipeline/toc_filter.rb
+++ b/lib/html/pipeline/toc_filter.rb
@@ -25,6 +25,11 @@ module HTML
     class TableOfContentsFilter < Filter
       PUNCTUATION_REGEXP = RUBY_VERSION > "1.9" ? /[^\p{Word}\- ]/u : /[^\w\- ]/
 
+      # The icon that will be placed next to an anchored rendered markdown header
+      def anchor_icon
+        context[:anchor_icon] || "<span aria-hidden=\"true\" class=\"octicon octicon-link\"></span>"
+      end
+
       def call
         result[:toc] = ""
 
@@ -39,7 +44,7 @@ module HTML
           headers[id] += 1
           if header_content = node.children.first
             result[:toc] << %Q{<li><a href="##{id}#{uniq}">#{text}</a></li>\n}
-            header_content.add_previous_sibling(%Q{<a id="#{id}#{uniq}" class="anchor" href="##{id}#{uniq}" aria-hidden="true"><span class="octicon octicon-link"></span></a>})
+            header_content.add_previous_sibling(%Q{<a id="#{id}#{uniq}" class="anchor" href="##{id}#{uniq}" aria-hidden="true">#{anchor_icon}</a>})
           end
         end
         result[:toc] = %Q{<ul class="section-nav">\n#{result[:toc]}</ul>} unless result[:toc].empty?

--- a/test/html/pipeline/toc_filter_test.rb
+++ b/test/html/pipeline/toc_filter_test.rb
@@ -107,9 +107,9 @@ class HTML::Pipeline::TableOfContentsFilterTest < Minitest::Test
 
       rendered_h1s = TocFilter.call(orig).search('h1').map(&:to_s)
 
-      assert_equal "<h1>\n<a id=\"日本語\" class=\"anchor\" href=\"#%E6%97%A5%E6%9C%AC%E8%AA%9E\" aria-hidden=\"true\"><span class=\"octicon octicon-link\"></span></a>日本語</h1>",
+      assert_equal "<h1>\n<a id=\"日本語\" class=\"anchor\" href=\"#%E6%97%A5%E6%9C%AC%E8%AA%9E\" aria-hidden=\"true\"><span aria-hidden=\"true\" class=\"octicon octicon-link\"></span></a>日本語</h1>",
                    rendered_h1s[0]
-      assert_equal "<h1>\n<a id=\"Русский\" class=\"anchor\" href=\"#%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\" aria-hidden=\"true\"><span class=\"octicon octicon-link\"></span></a>Русский</h1>",
+      assert_equal "<h1>\n<a id=\"Русский\" class=\"anchor\" href=\"#%D0%A0%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9\" aria-hidden=\"true\"><span aria-hidden=\"true\" class=\"octicon octicon-link\"></span></a>Русский</h1>",
                    rendered_h1s[1]
     end
 

--- a/test/html/pipeline/toc_filter_test.rb
+++ b/test/html/pipeline/toc_filter_test.rb
@@ -20,6 +20,13 @@ class HTML::Pipeline::TableOfContentsFilterTest < Minitest::Test
     assert_includes TocFilter.call(orig).to_s, '<a id='
   end
 
+  def test_custom_anchor_icons_added_properly
+    orig = %(<h1>Ice cube</h1>)
+    expected = %Q{<h1>\n<a id="ice-cube" class="anchor" href="#ice-cube" aria-hidden="true">#</a>Ice cube</h1>}
+
+    assert_equal expected, TocFilter.call(orig, {:anchor_icon => "#"}).to_s
+  end
+
   def test_toc_list_added_properly
     @orig = %(<h1>Ice cube</h1><p>Will swarm on any motherfucker in a blue uniform</p>)
     assert_includes toc, %Q{<ul class="section-nav">\n<li><a href="}


### PR DESCRIPTION
I want to create the option to pass in the icon for generated header anchors in the `TableOfContentsFilter`. This Pull aims to add that option as well as default the icon to the normal octicon.

-
@aroben @jch @simeonwillbanks 