### PR TITLE
Optionally filter email addresses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 group :development do
   gem "bundler"
   gem "rake"
-  gem "pry"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :development do
   gem "bundler"
   gem "rake"
+  gem "pry"
 end
 
 group :test do

--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -47,10 +47,12 @@ module HTML
         paragraphs = EmailReplyParser.read(text.dup).fragments.map do |fragment|
           pieces = [escape_html(fragment.to_s.strip).gsub(/^\s*(>|&gt;)/, '')]
           if fragment.quoted?
-            pieces.map! do |piece|
-              lines = piece.lines
-              lines.first.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
-              lines
+            if context[:hide_quoted_email_addresses]
+              pieces.map! do |piece|
+                lines = piece.lines
+                lines.first.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
+                lines
+              end
             end
             pieces.unshift EMAIL_QUOTED_HEADER
             pieces << EMAIL_HEADER_END

--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -49,7 +49,9 @@ module HTML
           if fragment.quoted?
             if context[:hide_quoted_email_addresses]
               pieces.map! do |piece|
-                piece.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
+                lines = piece.lines
+                lines.first.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
+                lines
               end
             end
             pieces.unshift EMAIL_QUOTED_HEADER

--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -27,6 +27,8 @@ module HTML
       EMAIL_SIGNATURE_HEADER = %(<div class="email-signature-reply">).freeze
       EMAIL_FRAGMENT_HEADER  = %(<div class="email-fragment">).freeze
       EMAIL_HEADER_END       = "</div>".freeze
+      EMAIL_REGEX            = /[^@\s.][^@\s]*@\[?[a-z0-9.-]+\]?/
+      HIDDEN_EMAIL_PATTERN   = "***@***.***"
 
       # Scans an email body to determine which bits are quoted and which should
       # be hidden. EmailReplyParser is used to split the comment into an Array
@@ -45,6 +47,11 @@ module HTML
         paragraphs = EmailReplyParser.read(text.dup).fragments.map do |fragment|
           pieces = [escape_html(fragment.to_s.strip).gsub(/^\s*(>|&gt;)/, '')]
           if fragment.quoted?
+            pieces.map! do |piece|
+              lines = piece.lines
+              lines.first.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
+              lines
+            end
             pieces.unshift EMAIL_QUOTED_HEADER
             pieces << EMAIL_HEADER_END
           elsif fragment.signature?

--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -49,9 +49,7 @@ module HTML
           if fragment.quoted?
             if context[:hide_quoted_email_addresses]
               pieces.map! do |piece|
-                lines = piece.lines
-                lines.first.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
-                lines
+                piece.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
               end
             end
             pieces.unshift EMAIL_QUOTED_HEADER

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 EmailReplyFilter = HTML::Pipeline::EmailReplyFilter
 
 class HTML::Pipeline::EmailReplyFilterTest < Minitest::Test
-  def test_hides_email_addresses
-    filter = EmailReplyFilter.new(<<-EMAIL, :highlight => "coffeescript")
+  def setup
+    @body = <<-EMAIL
 Hey, don't send email addresses in comments. They aren't filtered.
 
 > On Mar 5, 2016, at 08:05, Hacker J. Hackerson <example@example.com> wrote:
@@ -15,9 +15,19 @@ Hey, don't send email addresses in comments. They aren't filtered.
 > Reply to this email directly or view it on GitHub.
 >
 EMAIL
+  end
 
-    doc = filter.call
-    refute_match %r(example@example.com), doc.to_s
-    assert_match %r(alreadyleaked@example.com), doc.to_s
+  def test_doesnt_hide_by_default
+    filter = EmailReplyFilter.new(@body)
+    doc = filter.call.to_s
+    assert_match %r(example@example.com), doc
+    assert_match %r(alreadyleaked@example.com), doc
+  end
+
+  def test_hides_email_addresses_when_configured
+    filter = EmailReplyFilter.new(@body, :hide_quoted_email_addresses => true)
+    doc = filter.call.to_s
+    refute_match %r(example@example.com), doc
+    assert_match %r(alreadyleaked@example.com), doc
   end
 end

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -28,6 +28,6 @@ EMAIL
     filter = EmailReplyFilter.new(@body, :hide_quoted_email_addresses => true)
     doc = filter.call.to_s
     refute_match %r(example@example.com), doc
-    refute_match %r(alreadyleaked@example.com), doc
+    assert_match %r(alreadyleaked@example.com), doc
   end
 end

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -27,6 +27,6 @@ EMAIL
     filter = EmailReplyFilter.new(@body, :hide_quoted_email_addresses => true)
     doc = filter.call.to_s
     refute_match %r(boatymcboatface@example.com), doc
-    assert_match %r(alreadyleaked@example.com), doc
+    refute_match %r(alreadyleaked@example.com), doc
   end
 end

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+EmailReplyFilter = HTML::Pipeline::EmailReplyFilter
+
+class HTML::Pipeline::EmailReplyFilterTest < Minitest::Test
+  def test_hides_email_addresses
+    filter = EmailReplyFilter.new(<<-EMAIL, :highlight => "coffeescript")
+Hey, don't send email addresses in comments. They aren't filtered.
+
+> On Mar 5, 2016, at 08:05, Hacker J. Hackerson <example@example.com> wrote:
+>
+> Sup. alreadyleaked@example.com
+>
+> —
+> Reply to this email directly or view it on GitHub.
+>
+EMAIL
+
+    doc = filter.call
+    refute_match %r(example@example.com), doc.to_s
+    assert_match %r(alreadyleaked@example.com), doc.to_s
+  end
+end

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -28,6 +28,6 @@ EMAIL
     filter = EmailReplyFilter.new(@body, :hide_quoted_email_addresses => true)
     doc = filter.call.to_s
     refute_match %r(example@example.com), doc
-    assert_match %r(alreadyleaked@example.com), doc
+    refute_match %r(alreadyleaked@example.com), doc
   end
 end

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -7,27 +7,26 @@ class HTML::Pipeline::EmailReplyFilterTest < Minitest::Test
     @body = <<-EMAIL
 Hey, don't send email addresses in comments. They aren't filtered.
 
-> On Mar 5, 2016, at 08:05, Hacker J. Hackerson <example@example.com> wrote:
+> On Mar 5, 2016, at 08:05, Boaty McBoatface <boatymcboatface@example.com> wrote:
 >
 > Sup. alreadyleaked@example.com
 >
 > —
 > Reply to this email directly or view it on GitHub.
->
 EMAIL
   end
 
   def test_doesnt_hide_by_default
     filter = EmailReplyFilter.new(@body)
     doc = filter.call.to_s
-    assert_match %r(example@example.com), doc
     assert_match %r(alreadyleaked@example.com), doc
+    assert_match %r(boatymcboatface@example.com), doc
   end
 
   def test_hides_email_addresses_when_configured
     filter = EmailReplyFilter.new(@body, :hide_quoted_email_addresses => true)
     doc = filter.call.to_s
-    refute_match %r(example@example.com), doc
+    refute_match %r(boatymcboatface@example.com), doc
     assert_match %r(alreadyleaked@example.com), doc
   end
 end


### PR DESCRIPTION
It is common for email replies with quoted content to include email addresses in banners from quoted text. These email addresses may have been marked as private and by commenting via email, their email address is exposed. e.g.

### Before 
```
This is the content of a reply immediately following a comment by me.

> On Thu, Aug 13, 2015, 6:18 PM Boaty McBoatface boaty@example.com wrote:
> 
> A previous comment of mine

>> On Thu, Aug 13, 2015, 2:30 PM Steve notifications@example.com wrote:
>>
>> An even older comment
```

### After

This adds a flag to the `EmailReplyFilter` that will `gsub` out things that look somewhat like email addresses (erring on the false positive side).

### Before 
```
This is the content of a reply immediately following a comment by me.

> On Thu, Aug 13, 2015, 6:18 PM Boaty McBoatface ***@***.*** wrote:
> 
> A previous comment of mine

>> On Thu, Aug 13, 2015, 2:30 PM Steve  ***@***.*** wrote:
>>
>> An even older comment
```

/cc @jch sorry I guess I forgot to hit submit before heading out for the weekend, tab was still open :smile: