### PR TITLE
Regression in EmailReplyPipeline: unfiltered content is being ommitted

### DIFF
--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -49,7 +49,7 @@ module HTML
           if fragment.quoted?
             if context[:hide_quoted_email_addresses]
               pieces.map! do |piece|
-                piece.gsub!(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
+                piece.gsub(EMAIL_REGEX, HIDDEN_EMAIL_PATTERN)
               end
             end
             pieces.unshift EMAIL_QUOTED_HEADER

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -29,4 +29,38 @@ EMAIL
     refute_match %r(boatymcboatface@example.com), doc
     refute_match %r(alreadyleaked@example.com), doc
   end
+
+  def test_preserves_non_email_content_while_filtering
+    str = <<-EMAIL
+> Thank you! I have some thoughts on this pull request.
+>
+>  *  acme provides cmake and a wrapper for it. Please use '$(TARGET)-cmake' instead of cmake -DCMAKE_TOOLCHAIN_FILE='$(CMAKE_TOOLCHAIN_FILE)' -DCMAKE_BUILD_TYPE=Release.
+
+Okay -- I'm afraid I just blindly copied the eigen3.mk file, since that's a library I'm familiar with :-)
+
+>  *  Do you need -DCMAKE_SYSTEM_PROCESSOR=x86?
+
+Yes, this is a bit dumb, but vc checks for that (or amd) to determine that it's not being built on ARM.
+
+--
+Boaty McBoatface | http://example.org
+EMAIL
+
+    filter = EmailReplyFilter.new(str, :hide_quoted_email_addresses => true)
+    doc = filter.call.to_s
+
+    expected = <<-EXPECTED
+<div class="email-quoted-reply"> Thank you! I have some thoughts on this pull request.
+
+  *  acme provides cmake and a wrapper for it. Please use &#39;$(TARGET)-cmake&#39; instead of cmake -DCMAKE_TOOLCHAIN_FILE=&#39;$(CMAKE_TOOLCHAIN_FILE)&#39; -DCMAKE_BUILD_TYPE=Release.</div>
+<div class="email-fragment">Okay -- I&#39;m afraid I just blindly copied the eigen3.mk file, since that&#39;s a library I&#39;m familiar with :-)</div>
+<div class="email-quoted-reply">  *  Do you need -DCMAKE_SYSTEM_PROCESSOR=x86?</div>
+<div class="email-fragment">Yes, this is a bit dumb, but vc checks for that (or amd) to determine that it&#39;s not being built on ARM.</div>
+<span class="email-hidden-toggle"><a href="#">&hellip;</a></span><div class="email-hidden-reply" style="display:none"><div class="email-signature-reply">--
+Boaty McBoatface | http:&#47;&#47;example.org</div>
+</div>
+EXPECTED
+
+    assert_equal(expected.chomp, doc)
+  end
 end


### PR DESCRIPTION
Introduced in https://github.com/jch/html-pipeline/pull/247/files#r61125778. I made the test green in 2.3 and copied it into this PR. I'm not sure if we need a more complicated test case but the bug is straightforward and so is the fix.

Whoops!

/cc @jch @aroben 