### PR TITLE
CamoFilter: use String#unpack to hexencode URLs

### DIFF
--- a/lib/html/pipeline/camo_filter.rb
+++ b/lib/html/pipeline/camo_filter.rb
@@ -86,7 +86,7 @@ module HTML
       # Private: helper to hexencode a string. Each byte ends up encoded into
       # two characters, zero padded value in the range [0-9a-f].
       def hexencode(str)
-        str.to_enum(:each_byte).map { |byte| format('%02x', byte) }.join
+        str.unpack('H*').first
       end
     end
   end


### PR DESCRIPTION
ruby's benchmark with 100_000 iterations report some performance
improvement (up to 80x on my machine) over iterating over each byte.

https://gist.github.com/glaszig/9d1975b1821a799c5db5957c4cff1539

```
Rehearsal -------------------------------------------------
interpolation   4.480000   0.010000   4.490000 (  4.481051)
String#unpack   0.100000   0.000000   0.100000 (  0.111963)
---------------------------------------- total: 4.590000sec

                    user     system      total        real
interpolation   4.490000   0.010000   4.500000 (  4.501468)
String#unpack   0.100000   0.000000   0.100000 (  0.109444)

        input: https://www.example.com/path/to/image.png
interpolation: 68747470733a2f2f7777772e6578616d706c652e636f6d2f706174682f746f2f696d6167652e706e67
String#unpack: 68747470733a2f2f7777772e6578616d706c652e636f6d2f706174682f746f2f696d6167652e706e67
```
