### PR TITLE
Make Emoji img attributes configurable

### DIFF
--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -14,6 +14,7 @@ module HTML
     #   :asset_root (required) - base url to link to emoji sprite
     #   :asset_path (optional) - url path to link to emoji sprite. :file_name can be used as a placeholder for the sprite file name. If no asset_path is set "emoji/:file_name" is used.
     #   :ignored_ancestor_tags (optional) - Tags to stop the emojification. Node has matched ancestor HTML tags will not be emojified. Default to pre, code, and tt tags. Extra tags please pass in the form of array, e.g., %w(blockquote summary).
+    #   :img_attrs (optional) - Attributes for generated img tag. E.g. Pass { "draggble" => true, "height" => nil } to set draggable attribute to "true" and clear height attribute of generated img tag.
     class EmojiFilter < Filter
 
       DEFAULT_IGNORED_ANCESTOR_TAGS = %w(pre code tt).freeze
@@ -71,40 +72,34 @@ module HTML
 
       # Build an emoji image tag
       def emoji_image_tag(name)
-        "<img #{img_html_attrs(name)}>"
+        html_attrs =
+          default_img_attrs(name).
+            merge!(customized_img_attrs(name)).
+            except(*customized_img_attrs(name).select { |_, v| v.nil? }.keys).
+            map { |attr, value| %(#{attr}="#{value}") }.join(" ".freeze)
+
+        "<img #{html_attrs}>"
       end
 
-      def img_html_attrs(name)
-        img_attrs(name).map { |attr, value| %(#{attr}="#{value}") }.join(" ")
-      end
-
-      def img_attrs(name)
-        user_overrides = customized_attrs(name).select { |k, v| !v.nil? }
-        excluded_keys = customized_attrs(name).select { |k, v| v.nil? }.keys
-        result = default_img_attrs(name).merge!(user_overrides)
-        result.except(*excluded_keys)
-      end
-
+      # Default attributes for img tag
       def default_img_attrs(name)
         {
-          "class" => "emoji",
+          "class" => "emoji".freeze,
           "title" => ":#{name}:",
           "alt" => ":#{name}:",
           "src" => "#{emoji_url(name)}",
-          "height" => "20",
-          "width" => "20",
-          "align" => "absmiddle",
+          "height" => "20".freeze,
+          "width" => "20".freeze,
+          "align" => "absmiddle".freeze,
         }
       end
 
-      def customized_attrs(name)
-        return {} unless context[:img_attrs]
+      def customized_img_attrs(name)
+        @_customized_img_attrs ||= begin
+          return {} unless context[:img_attrs]
 
-        @_custom_img_attributes ||= begin
-          custom_img_attributes = context[:img_attrs]
-
-          custom_img_attributes.each do |key, value|
-            custom_img_attributes[key] = value.call(name) if value.respond_to?(:call)
+          context[:img_attrs].each do |key, value|
+            context[:img_attrs][key] = value.call(name) if value.respond_to?(:call)
           end
         end
       end

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -71,7 +71,42 @@ module HTML
 
       # Build an emoji image tag
       def emoji_image_tag(name)
-        "<img class='emoji' title=':#{name}:' alt=':#{name}:' src='#{emoji_url(name)}' height='20' width='20' align='absmiddle' />"
+        "<img #{img_html_attrs(name)}>"
+      end
+
+      def img_html_attrs(name)
+        img_attrs(name).map { |attr, value| %(#{attr}="#{value}") }.join(" ")
+      end
+
+      def img_attrs(name)
+        user_overrides = customized_attrs(name).select { |k, v| !v.nil? }
+        excluded_keys = customized_attrs(name).select { |k, v| v.nil? }.keys
+        result = default_img_attrs(name).merge!(user_overrides)
+        result.except(*excluded_keys)
+      end
+
+      def default_img_attrs(name)
+        {
+          "class" => "emoji",
+          "title" => ":#{name}:",
+          "alt" => ":#{name}:",
+          "src" => "#{emoji_url(name)}",
+          "height" => "20",
+          "width" => "20",
+          "align" => "absmiddle",
+        }
+      end
+
+      def customized_attrs(name)
+        return {} unless context[:img_attrs]
+
+        @_custom_img_attributes ||= begin
+          custom_img_attributes = context[:img_attrs]
+
+          custom_img_attributes.each do |key, value|
+            custom_img_attributes[key] = value.call(name) if value.respond_to?(:call)
+          end
+        end
       end
 
       def emoji_url(name)

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -65,23 +65,30 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
 
   def test_img_tag_attributes
     body = ":shipit:"
-    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com'})
+    filter = EmojiFilter.new(body, {:asset_root => "https://foo.com"})
     doc = filter.call
     assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" height="20" width="20" align="absmiddle">), doc.to_html
   end
 
-  def test_img_custom_tag_attributes
+  def test_img_tag_attributes_can_be_customized
     body = ":shipit:"
-    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com', img_attrs: Hash("draggable"=> false, "height" => nil, "width" => nil, "align" => nil)})
+    filter = EmojiFilter.new(body, {:asset_root => "https://foo.com", img_attrs: Hash("draggable"=> "false", "height" => nil, "width" => nil, "align" => nil)})
     doc = filter.call
-    assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable=\"false\">), doc.to_html
+    assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable="false">), doc.to_html
   end
 
-  def test_img_attr_accept_proclike_object
+  def test_img_attrs_value_can_accept_proclike_object
     remove_colons = ->(name) { name.gsub(":", "") }
     body = ":shipit:"
-    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com', img_attrs: Hash("title" => remove_colons)})
+    filter = EmojiFilter.new(body, {:asset_root => "https://foo.com", img_attrs: Hash("title" => remove_colons)})
     doc = filter.call
     assert_equal %(<img class="emoji" title="shipit" alt=":shipit:" src="https://foo.com/emoji/shipit.png" height="20" width="20" align="absmiddle">), doc.to_html
+  end
+
+  def test_img_attrs_can_accept_symbolized_keys
+    body = ":shipit:"
+    filter = EmojiFilter.new(body, {:asset_root => "https://foo.com", img_attrs: Hash(draggable: false, height: nil, width: nil, align: nil)})
+    doc = filter.call
+    assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable="false">), doc.to_html
   end
 end

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -62,4 +62,26 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
     doc = filter.call
     assert_equal body, doc.to_html
   end
+
+  def test_img_tag_attributes
+    body = ":shipit:"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com'})
+    doc = filter.call
+    assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" height="20" width="20" align="absmiddle">), doc.to_html
+  end
+
+  def test_img_custom_tag_attributes
+    body = ":shipit:"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com', img_attrs: Hash("draggable"=> false, "height" => nil, "width" => nil, "align" => nil)})
+    doc = filter.call
+    assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable=\"false\">), doc.to_html
+  end
+
+  def test_img_attr_accept_proclike_object
+    remove_colons = ->(name) { name.gsub(":", "") }
+    body = ":shipit:"
+    filter = EmojiFilter.new(body, {:asset_root => 'https://foo.com', img_attrs: Hash("title" => remove_colons)})
+    doc = filter.call
+    assert_equal %(<img class="emoji" title="shipit" alt=":shipit:" src="https://foo.com/emoji/shipit.png" height="20" width="20" align="absmiddle">), doc.to_html
+  end
 end


### PR DESCRIPTION
Resolves #234

This Pull Request makes `img` tag attributes configuarable:

- [Keep old behavior](https://github.com/jch/html-pipeline/blob/6e5cd67faba15402b9222ffe3ce925186d37754b/test/html/pipeline/emoji_filter_test.rb#L66-L71)
- [Clear attribute you don't want, set to `nil` (`"height" => nil, "width" => nil, "align" => nil`)](https://github.com/jch/html-pipeline/blob/6e5cd67faba15402b9222ffe3ce925186d37754b/test/html/pipeline/emoji_filter_test.rb#L73-L78)
- Override / Clear `img` tag attributes
  * [Override by passing hash, e.g. `"draggable"=> false`](https://github.com/jch/html-pipeline/blob/6e5cd67faba15402b9222ffe3ce925186d37754b/test/html/pipeline/emoji_filter_test.rb#L73-L78)
  * [Attribute value also accepts proc-like object with `name` argument](https://github.com/jch/html-pipeline/blob/6e5cd67faba15402b9222ffe3ce925186d37754b/test/html/pipeline/emoji_filter_test.rb#L80-L86)

- [ ] patch version bump because we're compatible with old behavior
- These deprecated `img` attributes (`height='20' width='20' align='absmiddle'`) can be removed when there is a next major / minor version bump

@jch What do you think?