### PR TITLE
Switch to CommonMark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ addons:
   apt:
     sources:
       - libicu-dev
+      - kalakris-cmake
+    packages:
+      - cmake
 
 script: bundle exec rake
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem "rinku",              "~> 1.7",   :require => false
   gem "gemoji",             "~> 2.0",   :require => false
   gem "RedCloth",           "~> 4.2.9", :require => false
-  gem "github-markdown",    "~> 0.5",   :require => false
+  gem "commonmarker",       "~> 0.14",  :require => false
   gem "email_reply_parser", "~> 0.5",   :require => false
   gem "sanitize",           "~> 2.0",   :require => false
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ gem 'github-linguist'
 * `AutolinkFilter` - `rinku`
 * `EmailReplyFilter` - `escape_utils`, `email_reply_parser`
 * `EmojiFilter` - `gemoji`
-* `MarkdownFilter` - `github-markdown`
+* `MarkdownFilter` - `commonmarker`
 * `PlainTextInputFilter` - `escape_utils`
 * `SanitizationFilter` - `sanitize`
 * `SyntaxHighlightFilter` - `github-linguist`

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -16,7 +16,7 @@ group :test do
   gem "rinku", "~> 1.7", :require => false
   gem "gemoji", "~> 2.0", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
-  gem "github-markdown", "~> 0.5", :require => false
+  gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false
   gem "sanitize", "~> 2.0", :require => false
   gem "escape_utils", "~> 1.0", :require => false

--- a/gemfiles/rails_3.gemfile.lock
+++ b/gemfiles/rails_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    html-pipeline (2.4.2)
+    html-pipeline (2.5.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
 

--- a/gemfiles/rails_3.gemfile.lock
+++ b/gemfiles/rails_3.gemfile.lock
@@ -43,6 +43,8 @@ GEM
     arel (3.0.3)
     builder (3.0.4)
     charlock_holmes (0.7.3)
+    commonmarker (0.14.15)
+      ruby-enum (~> 0.5)
     email_reply_parser (0.5.8)
     erubis (2.7.0)
     escape_utils (1.0.1)
@@ -52,7 +54,6 @@ GEM
       escape_utils (~> 1.0.1)
       mime-types (~> 1.19)
       pygments.rb (~> 0.6.0)
-    github-markdown (0.6.9)
     hike (1.2.3)
     i18n (0.7.0)
     journey (1.0.4)
@@ -99,6 +100,8 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     rinku (1.7.3)
+    ruby-enum (0.7.1)
+      i18n
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sprockets (2.2.3)
@@ -121,11 +124,11 @@ DEPENDENCIES
   RedCloth (~> 4.2.9)
   appraisal
   bundler
+  commonmarker (~> 0.14)
   email_reply_parser (~> 0.5)
   escape_utils (~> 1.0)
   gemoji (~> 2.0)
   github-linguist (~> 2.10)
-  github-markdown (~> 0.5)
   html-pipeline!
   minitest
   rack (< 2)

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -16,7 +16,7 @@ group :test do
   gem "rinku", "~> 1.7", :require => false
   gem "gemoji", "~> 2.0", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
-  gem "github-markdown", "~> 0.5", :require => false
+  gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false
   gem "sanitize", "~> 2.0", :require => false
   gem "escape_utils", "~> 1.0", :require => false

--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -51,6 +51,8 @@ GEM
     arel (6.0.3)
     builder (3.2.2)
     charlock_holmes (0.7.3)
+    commonmarker (0.14.15)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.0.2)
     email_reply_parser (0.5.8)
     erubis (2.7.0)
@@ -61,7 +63,6 @@ GEM
       escape_utils (~> 1.0.1)
       mime-types (~> 1.19)
       pygments.rb (~> 0.6.0)
-    github-markdown (0.6.9)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -110,6 +111,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (11.2.2)
     rinku (1.7.3)
+    ruby-enum (0.7.1)
+      i18n
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sprockets (3.6.2)
@@ -132,11 +135,11 @@ DEPENDENCIES
   RedCloth (~> 4.2.9)
   appraisal
   bundler
+  commonmarker (~> 0.14)
   email_reply_parser (~> 0.5)
   escape_utils (~> 1.0)
   gemoji (~> 2.0)
   github-linguist (~> 2.10)
-  github-markdown (~> 0.5)
   html-pipeline!
   minitest
   rack (< 2)

--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    html-pipeline (2.4.2)
+    html-pipeline (2.5.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
 

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -15,7 +15,7 @@ group :test do
   gem "rinku", "~> 1.7", :require => false
   gem "gemoji", "~> 2.0", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
-  gem "github-markdown", "~> 0.5", :require => false
+  gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false
   gem "sanitize", "~> 2.0", :require => false
   gem "escape_utils", "~> 1.0", :require => false

--- a/gemfiles/rails_5.gemfile.lock
+++ b/gemfiles/rails_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    html-pipeline (2.4.2)
+    html-pipeline (2.5.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
 

--- a/gemfiles/rails_5.gemfile.lock
+++ b/gemfiles/rails_5.gemfile.lock
@@ -53,6 +53,8 @@ GEM
     arel (7.0.0)
     builder (3.2.2)
     charlock_holmes (0.7.3)
+    commonmarker (0.14.15)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.0.2)
     email_reply_parser (0.5.8)
     erubis (2.7.0)
@@ -63,7 +65,6 @@ GEM
       escape_utils (~> 1.0.1)
       mime-types (~> 1.19)
       pygments.rb (> 0.6.0)
-    github-markdown (0.6.9)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -111,6 +112,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (11.2.2)
     rinku (1.7.3)
+    ruby-enum (0.7.1)
+      i18n
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sprockets (3.6.2)
@@ -135,11 +138,11 @@ DEPENDENCIES
   RedCloth (~> 4.2.9)
   appraisal
   bundler
+  commonmarker (~> 0.14)
   email_reply_parser (~> 0.5)
   escape_utils (~> 1.0)
   gemoji (~> 2.0)
   github-linguist (~> 2.10)
-  github-markdown (~> 0.5)
   html-pipeline!
   minitest
   rails (~> 5.0.0)

--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -1,7 +1,7 @@
 begin
-  require "github/markdown"
+  require "commonmarker"
 rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'github-markdown' for MarkdownFilter. See README.md for details."
+  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'commonmarker' for MarkdownFilter. See README.md for details."
 end
 
 module HTML
@@ -23,8 +23,9 @@ module HTML
       # Convert Markdown to HTML using the best available implementation
       # and convert into a DocumentFragment.
       def call
-        mode = (context[:gfm] != false) ? :gfm : :markdown
-        html = GitHub::Markdown.to_html(@text, mode)
+        options = [:GITHUB_PRE_LANG]
+        options << :HARDBREAKS if context[:gfm] != false
+        html = CommonMarker.render_html(@text, options, [:table, :strikethrough, :tagfilter, :autolink])
         html.rstrip!
         html
       end

--- a/test/html/pipeline/markdown_filter_test.rb
+++ b/test/html/pipeline/markdown_filter_test.rb
@@ -76,24 +76,24 @@ class GFMTest < Minitest::Test
   end
 
   def test_turn_newlines_into_br_tags_in_simple_cases
-    assert_equal "<p>foo<br>\nbar</p>",
+    assert_equal "<p>foo<br />\nbar</p>",
                  gfm("foo\nbar")
   end
 
   def test_convert_newlines_in_all_groups
-    assert_equal "<p>apple<br>\npear<br>\norange</p>\n\n" +
-                 "<p>ruby<br>\npython<br>\nerlang</p>",
+    assert_equal "<p>apple<br />\npear<br />\norange</p>\n" +
+                 "<p>ruby<br />\npython<br />\nerlang</p>",
                  gfm("apple\npear\norange\n\nruby\npython\nerlang")
   end
 
   def test_convert_newlines_in_even_long_groups
-    assert_equal "<p>apple<br>\npear<br>\norange<br>\nbanana</p>\n\n" +
-                 "<p>ruby<br>\npython<br>\nerlang</p>",
+    assert_equal "<p>apple<br />\npear<br />\norange<br />\nbanana</p>\n" +
+                 "<p>ruby<br />\npython<br />\nerlang</p>",
                  gfm("apple\npear\norange\nbanana\n\nruby\npython\nerlang")
   end
 
   def test_not_convert_newlines_in_lists
-    assert_equal "<h1>foo</h1>\n\n<h1>bar</h1>",
+    assert_equal "<h1>foo</h1>\n<h1>bar</h1>",
                  gfm("# foo\n# bar")
     assert_equal "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>",
                  gfm("* foo\n* bar")


### PR DESCRIPTION
`github-markdown` has been long deprecated, and now that we're using `commonmarker` in prod at GitHub everywhere we used to use `github-markdown`, this seems like an appropriate switch.