### PR TITLE
Let users set the common marker extensions

### DIFF
--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -12,6 +12,8 @@ module HTML
     #
     # Context options:
     #   :gfm      => false    Disable GFM line-end processing
+    #   :commonmarker_extensions => [ :table, :strikethrough,
+    #      :tagfilter, :autolink ] Common marker extensions to include
     #
     # This filter does not write any additional information to the context hash.
     class MarkdownFilter < TextFilter
@@ -25,7 +27,10 @@ module HTML
       def call
         options = [:GITHUB_PRE_LANG]
         options << :HARDBREAKS if context[:gfm] != false
-        html = CommonMarker.render_html(@text, options, [:table, :strikethrough, :tagfilter, :autolink])
+        extensions = context.fetch(
+          :commonmarker_extensions,
+          [:table, :strikethrough, :tagfilter, :autolink])
+        html = CommonMarker.render_html(@text, options, extensions)
         html.rstrip!
         html
       end

--- a/test/html/pipeline/markdown_filter_test.rb
+++ b/test/html/pipeline/markdown_filter_test.rb
@@ -48,6 +48,19 @@ class HTML::Pipeline::MarkdownFilterTest < Minitest::Test
     assert_equal 1, doc.search('pre').size
     assert_equal 'ruby', doc.search('pre').first['lang']
   end
+
+  def test_standard_extensions
+    iframe = "<iframe src='http://www.google.com'></iframe>"
+    iframe_escaped = "&lt;iframe src='http://www.google.com'>&lt;/iframe>"
+    doc = MarkdownFilter.new(iframe).call
+    assert_equal(doc, iframe_escaped)
+  end
+
+  def test_changing_extensions
+    iframe = "<iframe src='http://www.google.com'></iframe>"
+    doc = MarkdownFilter.new(iframe, commonmarker_extensions: []).call
+    assert_equal(doc, iframe)
+  end
 end
 
 class GFMTest < Minitest::Test


### PR DESCRIPTION
Changes:
  - Expose the common marker extensions to the context.
  - Set a default list of ext.
  - Update docs.