### PR TITLE
Fix travis' bundle install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
+bundler_args: --path ../../vendor/bundle
 
 addons:
   apt:


### PR DESCRIPTION
It seems like a change in travis-ci's defaults (maybe [trusty as default?](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status) which has been rolling out over this period or some other undocumented change) has caused the Travis builds to fail at bundle install.

It looks like the defaults for bundle args changed from --path vendor/bundle to --deployment. It **seems like** changing this alone has fixed travis builds