### PR TITLE
Output underlying load error when wrapping

### DIFF
--- a/lib/html/pipeline.rb
+++ b/lib/html/pipeline.rb
@@ -44,6 +44,12 @@ module HTML
     autoload :TextFilter,            'html/pipeline/text_filter'
 
     class MissingDependencyError < LoadError; end
+    def self.require_dependency(name, requirer)
+      require name
+    rescue LoadError => e
+      raise MissingDependencyError,
+        "Missing dependency '#{name}' for #{requirer}. See README.md for details.\n#{e.class.name}: #{e}"
+    end
 
     # Our DOM implementation.
     DocumentFragment = Nokogiri::HTML::DocumentFragment

--- a/lib/html/pipeline/autolink_filter.rb
+++ b/lib/html/pipeline/autolink_filter.rb
@@ -1,8 +1,4 @@
-begin
-  require "rinku"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'rinku' for AutolinkFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("rinku", "AutolinkFilter")
 
 module HTML
   class Pipeline

--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -1,14 +1,5 @@
-begin
-  require "escape_utils"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'escape_utils' for EmailReplyFilter. See README.md for details."
-end
-
-begin
-  require "email_reply_parser"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'email_reply_parser' for EmailReplyFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("escape_utils", "EmailReplyFilter")
+HTML::Pipeline.require_dependency("email_reply_parser", "EmailReplyFilter")
 
 module HTML
   class Pipeline

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -1,10 +1,5 @@
 require "cgi"
-
-begin
-  require "gemoji"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'gemoji' for EmojiFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("gemoji", "EmojiFilter")
 
 module HTML
   class Pipeline

--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -1,8 +1,4 @@
-begin
-  require "commonmarker"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'commonmarker' for MarkdownFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("commonmarker", "MarkdownFilter")
 
 module HTML
   class Pipeline

--- a/lib/html/pipeline/plain_text_input_filter.rb
+++ b/lib/html/pipeline/plain_text_input_filter.rb
@@ -1,8 +1,4 @@
-begin
-  require "escape_utils"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'escape_utils' for PlainTextInputFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("escape_utils", "PlainTextInputFilter")
 
 module HTML
   class Pipeline

--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -1,8 +1,4 @@
-begin
-  require "sanitize"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'sanitize' for SanitizationFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("sanitize", "SanitizationFilter")
 
 module HTML
   class Pipeline

--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -1,8 +1,4 @@
-begin
-  require "linguist"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'github-linguist' for SyntaxHighlightFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("linguist", "SyntaxHighlightFilter")
 
 module HTML
   class Pipeline

--- a/lib/html/pipeline/textile_filter.rb
+++ b/lib/html/pipeline/textile_filter.rb
@@ -1,8 +1,4 @@
-begin
-  require "redcloth"
-rescue LoadError => _
-  raise HTML::Pipeline::MissingDependencyError, "Missing dependency 'RedCloth' for TextileFilter. See README.md for details."
-end
+HTML::Pipeline.require_dependency("redcloth", "RedCloth")
 
 module HTML
   class Pipeline

--- a/test/html/pipeline/require_helper_test.rb
+++ b/test/html/pipeline/require_helper_test.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+require "test_helper"
+
+class HTML::Pipeline::RequireHelperTest < Minitest::Test
+
+  def test_works_with_existing
+    HTML::Pipeline.require_dependency('rake', 'SomeClass')
+  end
+
+  def test_raises_mising_dependency_error
+    assert_raises HTML::Pipeline::MissingDependencyError do
+      HTML::Pipeline.require_dependency('non-existant', 'SomeClass')
+    end
+  end
+
+  def test_raises_error_including_message
+    error = assert_raises(LoadError) do
+      HTML::Pipeline.require_dependency('non-existant', 'SomeClass')
+    end
+    assert_includes(error.message, "Missing dependency 'non-existant' for SomeClass. See README.md for details.")
+  end
+
+  def test_raises_error_includes_underlying_message
+    error = assert_raises LoadError do
+      HTML::Pipeline.require_dependency('non-existant', 'SomeClass')
+    end
+    assert_includes(error.message, "LoadError: cannot load such file")
+  end
+end


### PR DESCRIPTION
Fixes #282. Depends on #283 for travis.

In the end it seemed cleaner (and safer) to create a tested utility-method for catching the LoadError and then reissuing with added information.

Currently in separate commits for ease of reading, but can squash /rebase if desired.