### PR TITLE
EmojiFilter: img alt tag should contain screen-reader-friendly alt text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku",              "~> 1.7",   :require => false
-  gem "gemoji",             ">= 2.0",   :require => false
+  gem "gemoji",             ">= 2.0, < 4",   :require => false
   gem "RedCloth",           "~> 4.2.9", :require => false
   gem "commonmarker",       "~> 0.14",  :require => false
   gem "email_reply_parser", "~> 0.5",   :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku",              "~> 1.7",   :require => false
-  gem "gemoji",             "~> 2.0",   :require => false
+  gem "gemoji",             ">= 2.0",   :require => false
   gem "RedCloth",           "~> 4.2.9", :require => false
   gem "commonmarker",       "~> 0.14",  :require => false
   gem "email_reply_parser", "~> 0.5",   :require => false

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -14,7 +14,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku", "~> 1.7", :require => false
-  gem "gemoji", "~> 2.0", :require => false
+  gem "gemoji", ">= 2.0", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
   gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -14,7 +14,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku", "~> 1.7", :require => false
-  gem "gemoji", ">= 2.0", :require => false
+  gem "gemoji", ">= 2.0, < 4", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
   gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -14,7 +14,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku", "~> 1.7", :require => false
-  gem "gemoji", "~> 2.0", :require => false
+  gem "gemoji", ">= 2.0", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
   gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -14,7 +14,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku", "~> 1.7", :require => false
-  gem "gemoji", ">= 2.0", :require => false
+  gem "gemoji", ">= 2.0, < 4", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
   gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -13,7 +13,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku", "~> 1.7", :require => false
-  gem "gemoji", "~> 2.0", :require => false
+  gem "gemoji", ">= 2.0", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
   gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -13,7 +13,7 @@ end
 group :test do
   gem "minitest"
   gem "rinku", "~> 1.7", :require => false
-  gem "gemoji", ">= 2.0", :require => false
+  gem "gemoji", ">= 2.0, < 4", :require => false
   gem "RedCloth", "~> 4.2.9", :require => false
   gem "commonmarker", "~> 0.14", :require => false
   gem "email_reply_parser", "~> 0.5", :require => false

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -82,7 +82,7 @@ module HTML
         {
           "class" => "emoji".freeze,
           "title" => ":#{name}:",
-          "alt" => ":#{name}:",
+          "alt" => "#{emoji_description(name)}",
           "src" => "#{emoji_url(name)}",
           "height" => "20".freeze,
           "width" => "20".freeze,
@@ -109,6 +109,16 @@ module HTML
 
       def emoji_filename(name)
         Emoji.find_by_alias(name).image_filename
+      end
+
+      def emoji_description(name)
+        # Gemoji 3 introduced a description for emoji which is better suited for screen readers.
+        if Emoji.find_by_alias(name).respond_to?(:description)
+          description = Emoji.find_by_alias(name).description
+          return "#{description} emoji" unless description.nil? ||  description.empty?
+        end
+
+        ":#{name}:"
       end
 
       # Return ancestor tags to stop the emojification.

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -91,4 +91,11 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
     doc = filter.call
     assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable="false">), doc.to_html
   end
+
+  def test_img_tag_attrs_screen_reader_alt_when_available
+    body = ":key:"
+    filter = EmojiFilter.new(body, {:asset_root => "https://foo.com"})
+    doc = filter.call
+    assert_equal %(<img class="emoji" title=":key:" alt="key emoji" src="https://foo.com/emoji/unicode/1f511.png" height="20" width="20" align="absmiddle">), doc.to_html
+  end
 end


### PR DESCRIPTION
Currently, alt text like ":+1:" is not accessible for screen readers.
Gemoji v3.x introduced plain-English descriptions, which are a superior
solution for screen readers. Instead of "colon plus sign one colon", the
reader will instead hear "thumbs up emoji."

There are several GitHub-specific emoji which do not have descriptions.
Those can be added to the database in the github/gemoji repository.

This was originally requested by @hectorsector in https://github.com/jekyll/jemoji/issues/67.

What do you think?