### PR TITLE
Disable processing @mentions in <script> tag

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -65,7 +65,7 @@ module HTML
       )
 
       # Don't look for mentions in text nodes that are children of these elements
-      IGNORE_PARENTS = %w(pre code a style).to_set
+      IGNORE_PARENTS = %w(pre code a style script).to_set
 
       def call
         result[:mentioned_usernames] ||= []


### PR DESCRIPTION
Resolve #250 

This is to allow users to embed `json-ld` type scripts inlined within an HTML document..
Personally, I'm of the opinion that all `<script>' should be left untouched by a filter