### PR TITLE
Ensure <pre> nodes are not removed after syntax highlighting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development do
 end
 
 group :test do
-  gem 'commonmarker', '~> 0.14', require: false
+  gem 'commonmarker', '~> 0.16', require: false
   gem 'email_reply_parser', '~> 0.5', require: false
   gem 'gemoji', '~> 2.0', require: false
   gem 'minitest'

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ Rake::TestTask.new do |t|
   t.libs << 'test'
   t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
+  t.warning = false
 end
 
 task default: :test

--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -20,9 +20,10 @@ module HTML
           html = highlight_with_timeout_handling(text, lang)
           next if html.nil?
 
-          next unless (node = node.replace(html).first)
+          node.inner_html = html
           klass = node['class']
-          klass = [klass, "highlight-#{lang}"].compact.join ' '
+          scope = context[:scope] || "highlight-#{lang}"
+          klass = [klass, scope].compact.join ' '
 
           node['class'] = klass
         end

--- a/test/html/pipeline/syntax_highlight_filter_test.rb
+++ b/test/html/pipeline/syntax_highlight_filter_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'escape_utils'
 
 SyntaxHighlightFilter = HTML::Pipeline::SyntaxHighlightFilter
 
@@ -18,5 +19,44 @@ class HTML::Pipeline::SyntaxHighlightFilterTest < Minitest::Test
     doc = filter.call
     assert doc.css('.highlight-coffeescript').empty?
     assert !doc.css('.highlight-c').empty?
+  end
+
+  def test_highlight_does_not_remove_pre_tag
+    filter = SyntaxHighlightFilter.new \
+      "<pre lang='c'>hello</pre>", highlight: 'coffeescript'
+
+    doc = filter.call
+
+    assert !doc.css('pre').empty?
+  end
+
+  def test_highlight_allows_optional_scope
+    filter = SyntaxHighlightFilter.new \
+      "<pre lang='c'>hello</pre>", highlight: 'coffeescript', scope: 'test-scope'
+
+    doc = filter.call
+
+    assert !doc.css('pre.test-scope').empty?
+  end
+
+  def test_highlight_keeps_the_pre_tags_lang
+    filter = SyntaxHighlightFilter.new \
+      "<pre lang='c'>hello</pre>", highlight: 'coffeescript'
+
+    doc = filter.call
+
+    assert !doc.css('pre[lang=c]').empty?
+  end
+
+  def test_highlight_handles_nested_pre_tags
+    inner_code = "<pre>console.log('i am nested!')</pre>"
+    escaped = EscapeUtils.escape_html(inner_code)
+    html = "<pre lang='html'>#{escaped}</pre>"
+    filter = SyntaxHighlightFilter.new html, highlight: 'html'
+
+    doc = filter.call
+
+    assert_equal 2, doc.css('span[class=nt]').length
+    assert_equal EscapeUtils.unescape_html(escaped), doc.inner_text
   end
 end


### PR DESCRIPTION
After upgrading to rouge, I noticed the syntax highlighting in `octodown` has
disappeared. It seems that the `pre` tags were being removed, which are
neccesary for correct highlighting with rouge. This commit fixes this by
replacing the `inner_html` of the preblock with the code highlighted by rouge.