### PR TITLE
Adds `UNSAFE` option to CommonMarker usage where needed

### DIFF
--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -23,6 +23,7 @@ module HTML
       def call
         options = [:GITHUB_PRE_LANG]
         options << :HARDBREAKS if context[:gfm] != false
+        options << :UNSAFE if context[:unsafe]
         extensions = context.fetch(
           :commonmarker_extensions,
           %i[table strikethrough tagfilter autolink]

--- a/test/html/pipeline/markdown_filter_test.rb
+++ b/test/html/pipeline/markdown_filter_test.rb
@@ -52,20 +52,20 @@ class HTML::Pipeline::MarkdownFilterTest < Minitest::Test
   def test_standard_extensions
     iframe = "<iframe src='http://www.google.com'></iframe>"
     iframe_escaped = "&lt;iframe src='http://www.google.com'>&lt;/iframe>"
-    doc = MarkdownFilter.new(iframe).call
+    doc = MarkdownFilter.new(iframe, unsafe: true).call
     assert_equal(doc, iframe_escaped)
   end
 
   def test_changing_extensions
     iframe = "<iframe src='http://www.google.com'></iframe>"
-    doc = MarkdownFilter.new(iframe, commonmarker_extensions: []).call
+    doc = MarkdownFilter.new(iframe, commonmarker_extensions: [], unsafe: true).call
     assert_equal(doc, iframe)
   end
 end
 
 class GFMTest < Minitest::Test
   def gfm(text)
-    MarkdownFilter.call(text, gfm: true)
+    MarkdownFilter.call(text, gfm: true, unsafe: true)
   end
 
   def test_not_touch_single_underscores_inside_words


### PR DESCRIPTION
With the [release of commonmarker 0.18.0](https://github.com/gjtorikian/commonmarker/releases/tag/v0.18.0), HTML safety was introduced as a default (to avoid XSS).  But if someone _wants_ to allow unsafe elements in their markdown, they should be able to pass that option down to CommonMarker through html-pipeline.

Usage from my app:

```
# without the `unsafe` option being specified:
> HTML::Pipeline.new([HTML::Pipeline::MarkdownFilter])
    .call('<a href="http://example.com">Link</a>')
=> {:output=>"<p><!-- raw HTML omitted -->Link<!-- raw HTML omitted --></p>"}

# with the `unsafe` option being specified:
> HTML::Pipeline.new([HTML::Pipeline::MarkdownFilter])
    .call('<a href="http://example.com">Link</a>', unsafe: true)
=> {:output=>"<p><a href=\"http://example.com\">Link</a></p>"}
```