### PR TITLE
Whitelist various inline semantic/formatting tags

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -43,6 +43,7 @@ module HTML
           div ins del sup sub p ol ul table thead tbody tfoot blockquote
           dl dt dd kbd q samp var hr ruby rt rp li tr td th s strike summary
           details caption figure figcaption
+          abbr bdo cite dfn mark small span time wbr
         ].freeze,
         remove_contents: ['script'].freeze,
         attributes: {
@@ -109,7 +110,7 @@ module HTML
       # protocols, and transformers from WHITELIST but with a more locked down
       # set of allowed elements.
       LIMITED = WHITELIST.merge(
-        elements: %w[b i strong em a pre code img ins del sup sub p ol ul li]
+        elements: %w[b i strong em a pre code img ins del sup sub mark abbr p ol ul li]
       )
 
       # Strip all HTML tags from the document.


### PR DESCRIPTION
Mostly I want `<abbr>`, but the rest of these should also be whitelisted.

What goes in LIMITED.elements seems to be a bit subjective, but I think that `<mark>` and `<abbr>` at least are reasonably justified. `<dfn>` is fairly obscure, and `<small>`, `<bdo>`, `<cite>`, `<span>`, `<time>` and `<wbr>` a bit different from the rest and probably not justified, so I left them out.

In the absence of styling, `<span>` is quite useless, but `<div>`’s there already, and people have asked for `<span>` (#183), so I figured, why not?

Fixes #183.