### PR TITLE
Avoid YARD warning: Unknown tag @mention

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -81,8 +81,8 @@ module HTML
         doc
       end
 
-      # The URL to provide when someone @mentions a "mention" name, such as
-      # @mention or @mentioned, that will give them more info on mentions.
+      # The URL to provide when someone @mentions a "mention" name, such
+      # [UnknownTag] Unknown tag @mentionas @mention or @mentioned, that will give them more info on mentions.
       def info_url
         context[:info_url] || nil
       end

--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -82,7 +82,7 @@ module HTML
       end
 
       # The URL to provide when someone @mentions a "mention" name, such
-      # [UnknownTag] Unknown tag @mentionas @mention or @mentioned, that will give them more info on mentions.
+      # as @mention or @mentioned, that will give them more info on mentions.
       def info_url
         context[:info_url] || nil
       end


### PR DESCRIPTION
This PR avoids a YARD warning 

`[UnknownTag] Unknown tag @mention`

by not having the `@` as the first character on the comment line.