### PR TITLE
Team mention filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ EmojiPipeline = Pipeline.new [
 ## Filters
 
 * `MentionFilter` - replace `@user` mentions with links
+* `TeamMentionFilter` - replace `@org/team` mentions with links
 * `AbsoluteSourceFilter` - replace relative image urls with fully qualified versions
 * `AutolinkFilter` - auto_linking urls in HTML
 * `CamoFilter` - replace http image urls with [camo-fied](https://github.com/atmos/camo) https versions

--- a/lib/html/pipeline.rb
+++ b/lib/html/pipeline.rb
@@ -38,6 +38,7 @@ module HTML
     autoload :ImageMaxWidthFilter,   'html/pipeline/image_max_width_filter'
     autoload :MarkdownFilter,        'html/pipeline/markdown_filter'
     autoload :MentionFilter,         'html/pipeline/@mention_filter'
+    autoload :TeamMentionFilter,     'html/pipeline/@team_mention_filter'
     autoload :PlainTextInputFilter,  'html/pipeline/plain_text_input_filter'
     autoload :SanitizationFilter,    'html/pipeline/sanitization_filter'
     autoload :SyntaxHighlightFilter, 'html/pipeline/syntax_highlight_filter'

--- a/lib/html/pipeline/@team_mention_filter.rb
+++ b/lib/html/pipeline/@team_mention_filter.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'pry'
+
+module HTML
+  class Pipeline
+    # HTML filter that replaces @org/team mentions with links. Mentions within <pre>,
+    # <code>, <a>, <style>, and <script> elements are ignored.
+    #
+    # Context options:
+    #   :base_url - Used to construct links to team profile pages for each
+    #               mention.
+    #   :team_pattern - Used to provide a custom regular expression to
+    #                       identify team names
+    #
+    class TeamMentionFilter < Filter
+      # Public: Find @org/team mentions in text.  See
+      # TeamMentionFilter#team_mention_link_filter.
+      #
+      #   TeamMentionFilter.mentioned_teams_in(text) do |match, org, team|
+      #     "<a href=...>#{team}</a>"
+      #   end
+      #
+      # text - String text to search.
+      #
+      # Yields the String match, org name, and team name.  The yield's 
+      # return replaces the match in the original text.
+      #
+      # Returns a String replaced with the return of the block.
+      def self.mentioned_teams_in(text, team_pattern = TeamPattern)
+        text.gsub team_pattern do |match|
+          org = $1
+          team = $2
+          yield match, org, team
+        end
+      end
+
+      # Default pattern used to extract team names from text. The value can be
+      # overridden by providing the team_pattern variable in the context. To
+      # properly link the mention, should be in the format of /@(1)\/(2)/.
+      TeamPattern = /
+        (?<=^|\W)                  # beginning of string or non-word char
+        @([a-z0-9][a-z0-9-]*)      # @organization
+          \/                       # dividing slash
+          ([a-z0-9][a-z0-9\-_]*)   # team
+          \b
+      /ix
+
+      # Don't look for mentions in text nodes that are children of these elements
+      IGNORE_PARENTS = %w(pre code a style script).to_set
+
+      def call
+        result[:mentioned_teams] ||= []
+
+        doc.search('.//text()').each do |node|
+          content = node.to_html
+          next unless content.include?('@')
+          next if has_ancestor?(node, IGNORE_PARENTS)
+          html = mention_link_filter(content, base_url, team_pattern)
+          next if html == content
+          node.replace(html)
+        end
+        doc
+      end
+
+      def team_pattern
+        context[:team_pattern] || TeamPattern
+      end
+
+      # Replace @org/team mentions in text with links to the mentioned user's
+      # profile page.
+      #
+      # text      - String text to replace @mention team names in.
+      # base_url  - The base URL used to construct team profile URLs.
+      # team_pattern  - Regular expression used to identify teams in text
+      #
+      # Returns a string with @team mentions replaced with links. All links have a
+      # 'team-mention' class name attached for styling.
+      def mention_link_filter(text, _base_url = '/', team_pattern = TeamPattern)
+        self.class.mentioned_teams_in(text, team_pattern) do |match, org, team|
+          link = link_to_mentioned_team(org, team)
+
+          link ? match.sub("@#{org}/#{team}", link) : match
+        end
+      end
+
+      def link_to_mentioned_team(org, team)
+        result[:mentioned_teams] |= [team]
+
+        url = base_url.dup
+        url << '/' unless url =~ /[\/~]\z/
+        
+        "<a href='#{url << org}/#{team}' class='team-mention'>" \
+          "@#{org}/#{team}" \
+          '</a>'
+      end
+    end
+  end
+end

--- a/lib/html/pipeline/@team_mention_filter.rb
+++ b/lib/html/pipeline/@team_mention_filter.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 require 'set'
-require 'pry'
 
 module HTML
   class Pipeline
-    # HTML filter that replaces @org/team mentions with links. Mentions within <pre>,
-    # <code>, <a>, <style>, and <script> elements are ignored.
+    # HTML filter that replaces @org/team mentions with links. Mentions within
+    # <pre>, <code>, <a>, <style>, and <script> elements are ignored.
     #
     # Context options:
     #   :base_url - Used to construct links to team profile pages for each
@@ -24,7 +23,7 @@ module HTML
       #
       # text - String text to search.
       #
-      # Yields the String match, org name, and team name.  The yield's 
+      # Yields the String match, org name, and team name.  The yield's
       # return replaces the match in the original text.
       #
       # Returns a String replaced with the return of the block.
@@ -48,7 +47,7 @@ module HTML
       /ix
 
       # Don't look for mentions in text nodes that are children of these elements
-      IGNORE_PARENTS = %w(pre code a style script).to_set
+      IGNORE_PARENTS = %w[pre code a style script].to_set
 
       def call
         result[:mentioned_teams] ||= []
@@ -68,11 +67,11 @@ module HTML
         context[:team_pattern] || TeamPattern
       end
 
-      # Replace @org/team mentions in text with links to the mentioned user's
-      # profile page.
+      # Replace @org/team mentions in text with links to the mentioned team's
+      # page.
       #
       # text      - String text to replace @mention team names in.
-      # base_url  - The base URL used to construct team profile URLs.
+      # base_url  - The base URL used to construct team page URLs.
       # team_pattern  - Regular expression used to identify teams in text
       #
       # Returns a string with @team mentions replaced with links. All links have a

--- a/test/html/pipeline/team_mention_filter_test.rb
+++ b/test/html/pipeline/team_mention_filter_test.rb
@@ -88,6 +88,14 @@ class HTML::Pipeline::TeamMentionFilterTest < Minitest::Test
                  filter(body, '/~').to_html
   end
 
+  def test_multiple_team_mentions
+    body = '<p>Hi, @github/whale and @github/donut!</p>'
+    link_whale = '<a href="/github/whale" class="team-mention">@github/whale</a>'
+    link_donut = '<a href="/github/donut" class="team-mention">@github/donut</a>'
+    assert_equal "<p>Hi, #{link_whale} and #{link_donut}!</p>",
+                 filter(body).to_html
+  end
+
   MarkdownPipeline =
     HTML::Pipeline.new [
       HTML::Pipeline::MarkdownFilter,

--- a/test/html/pipeline/team_mention_filter_test.rb
+++ b/test/html/pipeline/team_mention_filter_test.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HTML::Pipeline::TeamMentionFilterTest < Minitest::Test
+  def filter(html, base_url = '/', team_pattern = nil)
+    HTML::Pipeline::TeamMentionFilter.call(html, base_url: base_url, team_pattern: team_pattern)
+  end
+
+  def test_filtering_plain_text
+    body = '<p>@github/team: check it out.</p>'
+    res  = filter(body, '/')
+
+    link = '<a href="/github/team" class="team-mention">@github/team</a>'
+    assert_equal "<p>#{link}: check it out.</p>",
+                 res.to_html
+  end
+
+  def test_filtering_a_documentfragment
+    body = '<p>@github/team: check it out.</p>'
+    doc  = Nokogiri::HTML::DocumentFragment.parse(body)
+
+    res  = filter(doc, '/')
+    assert_same doc, res
+
+    link = '<a href="/github/team" class="team-mention">@github/team</a>'
+    assert_equal "<p>#{link}: check it out.</p>",
+                 res.to_html
+  end
+
+  def test_not_replacing_mentions_in_pre_tags
+    body = '<pre>@github/team: okay</pre>'
+    assert_equal body, filter(body).to_html
+  end
+
+  def test_not_replacing_mentions_in_code_tags
+    body = '<p><code>@github/team:</code> okay</p>'
+    assert_equal body, filter(body).to_html
+  end
+
+  def test_not_replacing_mentions_in_style_tags
+    body = '<style>@github/team (min-width: 768px) { color: red; }</style>'
+    assert_equal body, filter(body).to_html
+  end
+
+  def test_not_replacing_mentions_in_links
+    body = '<p><a>@github/team</a> okay</p>'
+    assert_equal body, filter(body).to_html
+  end
+
+  def test_entity_encoding_and_whatnot
+    body = "<p>@github&#47team what's up</p>"
+    link = '<a href="/github/team" class="team-mention">@github/team</a>'
+    assert_equal "<p>#{link} what's up</p>", filter(body, '/').to_html
+  end
+
+  def test_html_injection
+    body = '<p>@github/team &lt;script>alert(0)&lt;/script></p>'
+    link = '<a href="/github/team" class="team-mention">@github/team</a>'
+    assert_equal "<p>#{link} &lt;script&gt;alert(0)&lt;/script&gt;</p>",
+                 filter(body, '/').to_html
+  end
+
+  def test_links_to_nothing_with_user_mention
+    body = '<p>Hi, @kneath</p>'
+    assert_equal '<p>Hi, @kneath</p>',
+                 filter(body, '/').to_html
+  end
+
+  def test_base_url_slash
+    body = '<p>Hi, @github/team!</p>'
+    link = '<a href="/github/team" class="team-mention">@github/team</a>'
+    assert_equal "<p>Hi, #{link}!</p>",
+                 filter(body, '/').to_html
+  end
+
+  def test_base_url_under_custom_route
+    body = '<p>Hi, @org/team!</p>'
+    link = '<a href="www.github.com/org/team" class="team-mention">@org/team</a>'
+    assert_equal "<p>Hi, #{link}!</p>",
+      filter(body, 'www.github.com').to_html
+  end
+
+  def test_base_url_slash_with_tilde
+    body = '<p>Hi, @github/team!</p>'
+    link = '<a href="/~github/team" class="team-mention">@github/team</a>'
+    assert_equal "<p>Hi, #{link}!</p>",
+                 filter(body, '/~').to_html
+  end
+
+  MarkdownPipeline =
+    HTML::Pipeline.new [
+      HTML::Pipeline::MarkdownFilter,
+      HTML::Pipeline::TeamMentionFilter
+    ]
+
+  def mentioned_teams
+    result = {}
+    MarkdownPipeline.call(@body, {}, result)
+    result[:mentioned_teams]
+  end
+
+  def test_matches_teams_in_body
+    @body = '@test/team how are you?'
+    assert_equal %w[team], mentioned_teams
+  end
+
+  def test_matches_orgs_with_dashes
+    @body = 'hi @some-org/team'
+    assert_equal %w[team], mentioned_teams
+  end
+
+  def test_matches_teams_with_dashes
+    @body = 'hi @github/some-team'
+    assert_equal %w[some-team], mentioned_teams
+  end
+
+  def test_matches_teams_followed_by_a_single_dot
+    @body = 'okay @github/team.'
+    assert_equal %w[team], mentioned_teams
+  end
+
+  def test_matches_teams_followed_by_multiple_dots
+    @body = 'okay @github/team...'
+    assert_equal %w[team], mentioned_teams
+  end
+
+  def test_does_not_match_email_addresses
+    @body = 'aman@tmm1.net'
+    assert_equal [], mentioned_teams
+  end
+
+  def test_does_not_match_domain_name_looking_things
+    @body = 'we need a @github.com email'
+    assert_equal [], mentioned_teams
+  end
+
+  def test_does_not_match_user_mentions
+    @body = 'we need to @enterprise know'
+    assert_equal [], mentioned_teams
+  end
+
+  def test_matches_colon_suffixed_team_names
+    @body = '@github/team: what do you think?'
+    assert_equal %w[team], mentioned_teams
+  end
+
+  def test_matches_list_of_teams
+    @body = '@github/whale @github/donut @github/green'
+    assert_equal %w[whale donut green], mentioned_teams
+  end
+
+  def test_matches_list_of_teams_with_commas
+    @body = '/cc @github/whale, @github/donut, @github/green'
+    assert_equal %w[whale donut green], mentioned_teams
+  end
+
+  def test_matches_inside_brackets
+    @body = '(@github/whale) and [@github/donut]'
+    assert_equal %w[whale donut], mentioned_teams
+  end
+
+  def test_returns_distinct_set
+    @body = '/cc @github/whale, @github/donut, @github/whale, @github/whale'
+    assert_equal %w[whale donut], mentioned_teams
+  end
+
+  def test_does_not_match_inline_code_block_with_multiple_code_blocks
+    @body = "something\n\n`/cc @github/whale @github/donut @github/green` `/cc @donut/donut`"
+    assert_equal %w[], mentioned_teams
+  end
+
+  def test_mention_at_end_of_parenthetical_sentence
+    @body = "(We're talking 'bout @some-org/some-team.)"
+    assert_equal %w[some-team], mentioned_teams
+  end
+
+  def test_team_pattern_can_be_customized
+    body = '<p>@_abc/XYZ: test</p>'
+    doc  = Nokogiri::HTML::DocumentFragment.parse(body)
+
+    res  = filter(doc, '/', /@(_[a-z]{3})\/([A-Z]{3})/)
+
+    link = '<a href="/_abc/XYZ" class="team-mention">@_abc/XYZ</a>'
+    assert_equal "<p>#{link}: test</p>",
+                 res.to_html
+  end
+
+  def test_mention_link_filter
+    filter = HTML::Pipeline::TeamMentionFilter.new nil
+    expected = "<a href='/bot/hubot' class='team-mention'>@bot/hubot</a>"
+    assert_equal expected, filter.mention_link_filter('@bot/hubot')
+  end
+end


### PR DESCRIPTION
Follow up for #311 - Adding a filter for `@org/team` mentions, built similarly to the existing `@user` mentions. Lmk if there's anything else you want me to add ✨