### PR TITLE
Reuse found lexer in SyntaxHighlightFilter

### DIFF
--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -17,9 +17,9 @@ module HTML
           default = context[:highlight] && context[:highlight].to_s
           next unless lang = node['lang'] || default
           next unless lexer = lexer_for(lang)
-          text = node.inner_text
 
-          html = highlight_with_timeout_handling(text, lang)
+          text = node.inner_text
+          html = highlight_with_timeout_handling(text, lexer)
           next if html.nil?
 
           node.inner_html = html
@@ -32,8 +32,8 @@ module HTML
         doc
       end
 
-      def highlight_with_timeout_handling(text, lang)
-        Rouge.highlight(text, lang, @formatter)
+      def highlight_with_timeout_handling(text, lexer)
+        Rouge.highlight(text, lexer, @formatter)
       rescue Timeout::Error => _
         nil
       end


### PR DESCRIPTION
This Pull Request: 

- Pass down the found lexer so we do not need to find that lexer again in [Rouge.highlight](https://github.com/rouge-ruby/rouge/blob/2caa1a09d8eb83188f5517f6070d2ff1631111d8/lib/rouge.rb#L25-L33)
~~- Remove `text = node.inner_text` local variable assignment since no one use it later on.~~