### PR TITLE
Improves syntax highlight filter

### DIFF
--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -23,11 +23,7 @@ module HTML
           next if html.nil?
 
           node.inner_html = html
-          klass = node['class']
-          scope = context[:scope] || "highlight-#{lang}"
-          klass = [klass, scope].compact.join ' '
-
-          node['class'] = klass
+          node['class'] = context[:scope] || "highlight-#{lang}"
         end
         doc
       end

--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -23,7 +23,8 @@ module HTML
           next if html.nil?
 
           node.inner_html = html
-          node['class'] = context[:scope] || "highlight-#{lang}"
+          scope = context.fetch(:scope) { 'highlight' }
+          node['class'] = "#{scope} #{scope}-#{lang}"
         end
         doc
       end

--- a/lib/html/pipeline/syntax_highlight_filter.rb
+++ b/lib/html/pipeline/syntax_highlight_filter.rb
@@ -4,8 +4,15 @@ HTML::Pipeline.require_dependency('rouge', 'SyntaxHighlightFilter')
 
 module HTML
   class Pipeline
-    # HTML Filter that syntax highlights code blocks wrapped
-    # in <pre lang="...">.
+    # HTML Filter that syntax highlights text inside code blocks.
+    #
+    # Context options:
+    #
+    #   :highlight => String represents the language to pick lexer. Defaults to empty string.
+    #   :scope => String represents the class attribute adds to pre element after.
+    #             Defaults to "highlight highlight-css" if highlights a css code block.
+    #
+    # This filter does not write any additional information to the context hash.
     class SyntaxHighlightFilter < Filter
       def initialize(*args)
         super(*args)

--- a/test/html/pipeline/syntax_highlight_filter_test.rb
+++ b/test/html/pipeline/syntax_highlight_filter_test.rb
@@ -11,6 +11,7 @@ class HTML::Pipeline::SyntaxHighlightFilterTest < Minitest::Test
       '<pre>hello</pre>', highlight: 'coffeescript'
 
     doc = filter.call
+    assert !doc.css('.highlight').empty?
     assert !doc.css('.highlight-coffeescript').empty?
   end
 


### PR DESCRIPTION
I recently upgraded a project from [3rd party syntax highlight filter](https://github.com/JuanitoFatas/html-pipeline-rouge_filter/blob/322ce295c22b5f02a8a86c52d4499fd348c228b2/lib/html/pipeline/rouge_filter.rb) to [`HTML::Pipeline::SyntaxHighlightFilter`](https://github.com/jch/html-pipeline/blob/13057c4dcde5e769dd116682f1bed7e65e920b40/lib/html/pipeline/syntax_highlight_filter.rb). Found the syntax highlight is not working anymore (missing `highlight` class from `pre` element. Fixed in dc42b12. 

Hence opened this Pull Request ☺️ 

1) Remove unused class assignment 2f7dc1b  
2) Fix css scope added to pre element dc42b12  
3) Improve documentations c594b66  

Please let me know if the commit message does not explain well. 
