### PR TITLE
Allow `role` attributes in html tags

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -69,7 +69,7 @@ module HTML
                   maxlength media method
                   multiple name nohref noshade
                   nowrap open prompt readonly rel rev
-                  rows rowspan rules scope
+                  role rows rowspan rules scope
                   selected shape size span
                   start summary tabindex target
                   title type usemap valign value


### PR DESCRIPTION
https://stackoverflow.com/questions/10403138/what-is-the-purpose-of-the-role-attribute-in-html

In my case, the motivation is to allow `<img src="math.svg" role="math" />`.