### PR TITLE
Add 'force_encoding' option to MarkdownFilter

### DIFF
--- a/lib/html/pipeline/markdown_filter.rb
+++ b/lib/html/pipeline/markdown_filter.rb
@@ -25,6 +25,9 @@ module HTML
       # Convert Markdown to HTML using the best available implementation
       # and convert into a DocumentFragment.
       def call
+        if encoding = context[:force_encoding]
+          @text.force_encoding(encoding)
+        end
         extensions = context.fetch(
           :commonmarker_extensions,
           DEFAULT_COMMONMARKER_EXTENSIONS

--- a/test/html/pipeline/markdown_filter_test.rb
+++ b/test/html/pipeline/markdown_filter_test.rb
@@ -38,6 +38,10 @@ class HTML::Pipeline::MarkdownFilterTest < Minitest::Test
 
     More words?
     DOC
+    @non_utf_text = String.new(
+      "These curly quotes “make commonmarker throw an exception”",
+      encoding: "ASCII-8BIT",
+    )
   end
 
   def test_fails_when_given_a_documentfragment
@@ -118,6 +122,14 @@ class HTML::Pipeline::MarkdownFilterTest < Minitest::Test
     results = MarkdownFilter.new(script, unsafe: true, commonmarker_extensions: extensions, commonmarker_renderer: CustomRenderer).call
 
     assert_equal results, script
+  end
+
+  def test_non_utf_content_allowed
+    # Without forcing encoding, test would fail with an error like:
+    #   Encoding::UndefinedConversionError: "\xE2" from ASCII-8BIT to UTF-8
+    #   [...]/gems/commonmarker-0.21.0/lib/commonmarker.rb:42:in `encode'
+    #   [...]/gems/commonmarker-0.21.0/lib/commonmarker.rb:42:in `render_doc'
+    MarkdownFilter.new(@non_utf_text, force_encoding: "UTF-8").call
   end
 end
 


### PR DESCRIPTION
Hello 👋 

This PR is to fix an open issue with a dependant project:
https://github.com/alphagov/govuk-developer-docs/issues/1821

HTML::Pipeline uses CommonMarker as its markdown parser in the
MarkdownFilter. CommonMarker throws an exception if it encounters
any non-UTF-8 content:
https://github.com/gjtorikian/commonmarker/pull/10/files#diff-5850b052ec7a5e6bd8b51bc53465146aR8

We would like to be able to pass a `force_encoding: "UTF-8"`
parameter to the context, which can be used to force encoding
prior to calling CommonMarker, so that the exception is avoided.

Thank you for considering our pull request.