### PR TITLE
Make AutolinkFilter configurable

### DIFF
--- a/lib/html/pipeline/autolink_filter.rb
+++ b/lib/html/pipeline/autolink_filter.rb
@@ -8,6 +8,7 @@ module HTML
     #
     # Context options:
     #   :autolink  - boolean whether to autolink urls
+    #   :link_mode - :all, :urls or :email_addresses
     #   :link_attr - HTML attributes for the link that will be generated
     #   :skip_tags - HTML tags inside which autolinking will be skipped.
     #                See Rinku.skip_tags
@@ -22,7 +23,11 @@ module HTML
         flags = 0
         flags |= context[:flags] if context[:flags]
 
-        Rinku.auto_link(html, :urls, context[:link_attr], skip_tags, flags)
+        Rinku.auto_link(html, link_mode, context[:link_attr], skip_tags, flags)
+      end
+
+      def link_mode
+        context[:link_mode] || :urls
       end
     end
   end

--- a/test/html/pipeline/autolink_filter_test.rb
+++ b/test/html/pipeline/autolink_filter_test.rb
@@ -34,4 +34,24 @@ class HTML::Pipeline::AutolinkFilterTest < Minitest::Test
     assert_equal '<code>"<a href="http://github.com">http://github.com</a>"</code>',
                  AutolinkFilter.to_html('<code>"http://github.com"</code>', skip_tags: %w[kbd script])
   end
+
+  def test_link_mode_default
+    assert_equal '<p>"<a href="http://www.github.com">http://www.github.com</a>"</p><p>"user@example.com"</p>',
+                 AutolinkFilter.to_html('<p>"http://www.github.com"</p><p>"user@example.com"</p>')
+  end
+
+  def test_link_mode_urls
+    assert_equal '<p>"<a href="http://www.github.com">http://www.github.com</a>"</p><p>"user@example.com"</p>',
+                 AutolinkFilter.to_html('<p>"http://www.github.com"</p><p>"user@example.com"</p>', link_mode: :urls)
+  end
+
+  def test_link_mode_all
+    assert_equal '<p>"<a href="http://www.github.com">http://www.github.com</a>"</p><p>"<a href="mailto:user@example.com">user@example.com</a>"</p>',
+                 AutolinkFilter.to_html('<p>"http://www.github.com"</p><p>"user@example.com"</p>', link_mode: :all)
+  end
+
+  def test_link_mode_email_addresses
+    assert_equal '<p>"http://www.github.com"</p><p>"<a href="mailto:user@example.com">user@example.com</a>"</p>',
+                 AutolinkFilter.to_html('<p>"http://www.github.com"</p><p>"user@example.com"</p>', link_mode: :email_addresses)
+  end
 end


### PR DESCRIPTION
### Description

This makes `AutolinkFilter` optionally accept the `:link_mode` context so that developers can switch the link mode of `Rinku.auto_link`. Currently the link mode is fixed to `:urls`. 

### Notes

- Since the `:link_mode` context has the default value of `:urls`, this change won't change existing behavior.
- [vmg/rinku gem doc](https://github.com/vmg/rinku)
